### PR TITLE
Adding a Github Action to compile firmware

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -1,4 +1,4 @@
-name: CLI CI
+name: Compile Firmware
 
 on:
   push:
@@ -11,10 +11,10 @@ on:
     - sn32_openrgb
 
 jobs:
-  test:
+  Build:
     runs-on: ubuntu-latest
 
-    container: qmkfm/base_container
+    container: jath03/sonix_base_container
 
     steps:
     - uses: actions/checkout@v2
@@ -27,5 +27,5 @@ jobs:
 
     - uses: actions/upload-artifact@v2
       with:
-        name: pre-compiled firmware
+        name: Pre-Compiled Firmware
         path: '*.bin'

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -1,0 +1,31 @@
+name: CLI CI
+
+on:
+  push:
+    branches:
+    - sn32
+    - sn32_openrgb
+  pull_request:
+    branches:
+    - sn32
+    - sn32_openrgb
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    container: qmkfm/base_container
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Install dependencies
+      run: pip3 install -r requirements.txt
+    - name: Build keyboards
+      run: python3 bin/build_all.py
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: pre-compiled firmware
+        path: '*.bin'

--- a/bin/build_all.py
+++ b/bin/build_all.py
@@ -1,7 +1,7 @@
 import subprocess
 import os
 
-BOARDS = ['redragon/k552', 'redragon/k556']
+BOARDS = ['redragon/k552', 'redragon/k556', 'keychron/k4', 'keychron/k6']
 
 for kb in BOARDS:
     subprocess.run(f"bin/qmk compile -kb {kb} -km default -j{os.cpu_count()}", shell=True)

--- a/bin/build_all.py
+++ b/bin/build_all.py
@@ -1,0 +1,7 @@
+import subprocess
+import os
+
+BOARDS = ['redragon/k552', 'redragon/k556']
+
+for kb in BOARDS:
+    subprocess.run(f"bin/qmk compile -kb {kb} -km default -j{os.cpu_count()}", shell=True)


### PR DESCRIPTION
This adds a GitHub Action that automatically compiles the firmware for a list of keyboards whenever a new commit is pushed to the the `sn32` or `sn32_openrgb` branches.  The compiled firmware binaries are downloadable as an artifact, a single zip file that contains all of the binaries.  