### PR TITLE
[Keyboard] Redragon: cleanup code for enabling indicators

### DIFF
--- a/keyboards/redragon/k552/config_led.h
+++ b/keyboards/redragon/k552/config_led.h
@@ -36,3 +36,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define LED_MATRIX_COL_PINS { A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, B0, B1 }
 
 #define DRIVER_LED_TOTAL (6*17)
+
+#define LED_NUM_LOCK_PIN B14
+#define LED_CAPS_LOCK_PIN B15
+#define LED_PIN_ON_STATE 0

--- a/keyboards/redragon/k552/led_matrix.c
+++ b/keyboards/redragon/k552/led_matrix.c
@@ -65,18 +65,6 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
 };
 
 void led_set(uint8_t usb_led) {
-    setPinOutput(B14);
-    setPinOutput(B15);
-
-    if (usb_led >> USB_LED_CAPS_LOCK & 1) {
-        writePinLow(B14);
-    } else {
-        writePinHigh(B14);
-    }
-
-    if (usb_led >> USB_LED_SCROLL_LOCK & 1) {
-        writePinLow(B15);
-    } else {
-        writePinHigh(B15);
-    }
+    writePin(LED_NUM_LOCK_PIN, !IS_LED_ON(usb_led, USB_LED_NUM_LOCK));
+    writePin(LED_CAPS_LOCK_PIN, !IS_LED_ON(usb_led, USB_LED_CAPS_LOCK));
 }

--- a/keyboards/redragon/k556/config_led.h
+++ b/keyboards/redragon/k556/config_led.h
@@ -36,3 +36,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define LED_MATRIX_COL_PINS { A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, B0, B1, B2, B3, B4, B5 }
 
 #define DRIVER_LED_TOTAL (6*21)
+
+#define LED_NUM_LOCK_PIN B13
+#define LED_CAPS_LOCK_PIN B14
+#define LED_SCROLL_LOCK_PIN B15
+#define LED_PIN_ON_STATE 0

--- a/keyboards/redragon/k556/led_matrix.c
+++ b/keyboards/redragon/k556/led_matrix.c
@@ -65,25 +65,7 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
 };
 
 void led_set(uint8_t usb_led) {
-    setPinOutput(B13);
-    setPinOutput(B14);
-    setPinOutput(B15);
-
-    if (usb_led >> USB_LED_NUM_LOCK & 1) {
-        writePinLow(B13);
-    } else {
-        writePinHigh(B13);
-    }
-
-    if (usb_led >> USB_LED_CAPS_LOCK & 1) {
-        writePinLow(B14);
-    } else {
-        writePinHigh(B14);
-    }
-
-    if (usb_led >> USB_LED_SCROLL_LOCK & 1) {
-        writePinLow(B15);
-    } else {
-        writePinHigh(B15);
-    }
+    writePin(LED_NUM_LOCK_PIN, !IS_LED_ON(usb_led, USB_LED_NUM_LOCK));
+    writePin(LED_CAPS_LOCK_PIN, !IS_LED_ON(usb_led, USB_LED_CAPS_LOCK));
+    writePin(LED_SCROLL_LOCK_PIN, !IS_LED_ON(usb_led, USB_LED_SCROLL_LOCK));
 }


### PR DESCRIPTION
## Description

This PR cleans the code for enabling LED indicators for caps, num and scroll lock keys. It makes use of macros and functions defined in `quantum.h`.

`#define LED_PIN_ON_STATE 0` is required, so we don't have to implement our custom init function (`led_init_ports`) to override the default quantum function to startup the LEDs; for the same reason we don't need to initialize these pins as output, they are already initialized in the `quantum/led.c` file.

https://github.com/SonixQMK/qmk_firmware/blob/sn32/quantum/led.c#L105

