### PR TITLE
Add support for Media Keys on k556 and equivalent

### DIFF
--- a/keyboards/redragon/k556/rules.mk
+++ b/keyboards/redragon/k556/rules.mk
@@ -46,7 +46,7 @@ MAGIC_ENABLE = yes
 MAGIC_KEYCODE_ENABLE = yes
 BOOTMAGIC_ENABLE = full # Virtual DIP switch configuration
 MOUSEKEY_ENABLE = no    # Mouse keys
-EXTRAKEY_ENABLE = no    # Audio control and System control
+EXTRAKEY_ENABLE = yes   # Audio control and System control
 CONSOLE_ENABLE = no     # Console for debug
 COMMAND_ENABLE = no     # Commands for debug and configuration
 SLEEP_LED_ENABLE = no   # Breathing sleep LED during USB suspend
@@ -56,6 +56,7 @@ RGBLIGHT_ENABLE = no
 SERIAL_LINK_ENABLE = no
 WAIT_FOR_USB = no
 CUSTOM_MATRIX = yes
+KEYBOARD_SHARED_EP = yes
 
 # Custom RGB matrix handling
 RGB_MATRIX_ENABLE = yes


### PR DESCRIPTION
Turns out it's just some options

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Enables Media Keys, and enabled Shared EP so that the PC can see them
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation
