### PR TITLE
[Redragon] Update indicators to use a "less deprecated" api

### DIFF
--- a/keyboards/redragon/k552/rev1/led_matrix.c
+++ b/keyboards/redragon/k552/rev1/led_matrix.c
@@ -64,7 +64,11 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
     .set_color_all = set_color_all,
 };
 
-void led_set(uint8_t usb_led) {
-    writePin(LED_CAPS_LOCK_PIN, !IS_LED_ON(usb_led, USB_LED_CAPS_LOCK));
-	writePin(LED_SCROLL_LOCK_PIN, !IS_LED_ON(usb_led, USB_LED_SCROLL_LOCK));
+bool led_update_kb(led_t led_state) {
+    bool res = led_update_user(led_state);
+    if(res) {
+        writePin(LED_CAPS_LOCK_PIN, !led_state.caps_lock);
+        writePin(LED_SCROLL_LOCK_PIN, !led_state.scroll_lock);
+    }
+    return res;
 }

--- a/keyboards/redragon/k552/rev2/led_matrix.c
+++ b/keyboards/redragon/k552/rev2/led_matrix.c
@@ -64,7 +64,11 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
     .set_color_all = set_color_all,
 };
 
-void led_set(uint8_t usb_led) {
-    writePin(LED_CAPS_LOCK_PIN, !IS_LED_ON(usb_led, USB_LED_CAPS_LOCK));
-    writePin(LED_SCROLL_LOCK_PIN, !IS_LED_ON(usb_led, USB_LED_SCROLL_LOCK));
+bool led_update_kb(led_t led_state) {
+    bool res = led_update_user(led_state);
+    if(res) {
+        writePin(LED_CAPS_LOCK_PIN, !led_state.caps_lock);
+        writePin(LED_SCROLL_LOCK_PIN, !led_state.scroll_lock);
+    }
+    return res;
 }

--- a/keyboards/redragon/k556/led_matrix.c
+++ b/keyboards/redragon/k556/led_matrix.c
@@ -64,8 +64,13 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
     .set_color_all = set_color_all,
 };
 
-void led_set(uint8_t usb_led) {
-    writePin(LED_NUM_LOCK_PIN, !IS_LED_ON(usb_led, USB_LED_NUM_LOCK));
-    writePin(LED_CAPS_LOCK_PIN, !IS_LED_ON(usb_led, USB_LED_CAPS_LOCK));
-    writePin(LED_SCROLL_LOCK_PIN, !IS_LED_ON(usb_led, USB_LED_SCROLL_LOCK));
+
+bool led_update_kb(led_t led_state) {
+    bool res = led_update_user(led_state);
+    if(res) {
+        writePin(LED_NUM_LOCK_PIN, !led_state.num_lock);
+        writePin(LED_CAPS_LOCK_PIN, !led_state.caps_lock);
+        writePin(LED_SCROLL_LOCK_PIN, !led_state.scroll_lock);
+    }
+    return res;
 }


### PR DESCRIPTION
Without changing any functionality, this changes the redragon keyboards' indicator code to use a "less deprecated" api ([source](https://beta.docs.qmk.fm/using-qmk/hardware-features/feature_led_indicators)).  This also makes it easier to modify indicator behavior at the keymap level.