### PR TITLE
Workaround SN32 USB code deficiencies for remote wakeup to work

### DIFF
--- a/tmk_core/protocol/chibios/main.c
+++ b/tmk_core/protocol/chibios/main.c
@@ -243,7 +243,14 @@ int main(void) {
                 /* Remote wakeup */
                 if (suspend_wakeup_condition()) {
                     usbWakeupHost(&USB_DRIVER);
+                    //Generally there is no need to restart usb driver
+                    //Change is introduced in https://github.com/qmk/qmk_firmware/pull/10088
+                    //Restarting driver entails bus disconnet/connect and device reenumeration
+                    //SN32 USB driver currently doesn't have proper handling for usb restart thus comment it for now
+                    //Alternatively it is posible to workaround it via ifndefs
+#if !defined(SN32F24xx)
                     restart_usb_driver(&USB_DRIVER);
+#endif
                 }
             }
             /* Woken up */


### PR DESCRIPTION
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
prevent usb driver restart after remote wakeup has been triggered.

<!--- Describe your changes in detail here. -->

Chibios-contrib got remote wakeup updates in SN32 USB driver.
Current handling of wakeup event in qmk restarts USB driver (see pr: https://github.com/qmk/qmk_firmware/pull/10088)
USB driver restart and enumeration is unnecessary in general however SN32 USB code doesn't handle driver restart properly.
Following need to be done to handle usb driver restart:
- bus disconnect/connect handling
- proper stop sequence
- address reset and reenumeration
While USB driver is restarted in qmk all EP configuration is destroyed (which will be initialized again after enumeration).
To shortcut deficiencies of SN32 USB code and avoid unnecessary reenumeration at each wakeup this PR disables usb driver  restart at remote wakeup.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

added remote wakeup handling


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
