### PR TITLE
sym_eager_g test

### DIFF
--- a/keyboards/ajazz/ak33/rev1/rules.mk
+++ b/keyboards/ajazz/ak33/rev1/rules.mk
@@ -60,3 +60,5 @@ CUSTOM_MATRIX = yes
 # Custom RGB matrix handling
 RGB_MATRIX_ENABLE = yes
 RGB_MATRIX_DRIVER = custom
+
+DEBOUNCE_TYPE = sym_eager_g

--- a/keyboards/ajazz/ak33/rev2/rules.mk
+++ b/keyboards/ajazz/ak33/rev2/rules.mk
@@ -61,3 +61,5 @@ KEYBOARD_SHARED_EP = yes
 # Custom RGB matrix handling
 RGB_MATRIX_ENABLE = yes
 RGB_MATRIX_DRIVER = custom
+
+DEBOUNCE_TYPE = sym_eager_g

--- a/keyboards/redragon/k552/rev1/rules.mk
+++ b/keyboards/redragon/k552/rev1/rules.mk
@@ -60,3 +60,5 @@ CUSTOM_MATRIX = yes
 # Custom RGB matrix handling
 RGB_MATRIX_ENABLE = yes
 RGB_MATRIX_DRIVER = custom
+
+DEBOUNCE_TYPE = sym_eager_g

--- a/keyboards/redragon/k552/rev2/rules.mk
+++ b/keyboards/redragon/k552/rev2/rules.mk
@@ -61,3 +61,5 @@ KEYBOARD_SHARED_EP = yes
 # Custom RGB matrix handling
 RGB_MATRIX_ENABLE = yes
 RGB_MATRIX_DRIVER = custom
+
+DEBOUNCE_TYPE = sym_eager_g

--- a/keyboards/redragon/k556/rules.mk
+++ b/keyboards/redragon/k556/rules.mk
@@ -61,3 +61,5 @@ KEYBOARD_SHARED_EP = yes
 # Custom RGB matrix handling
 RGB_MATRIX_ENABLE = yes
 RGB_MATRIX_DRIVER = custom
+
+DEBOUNCE_TYPE = sym_eager_g

--- a/quantum/debounce/sym_eager_g.c
+++ b/quantum/debounce/sym_eager_g.c
@@ -1,0 +1,55 @@
+/*
+Copyright 2017 Alex Ong<the.onga@gmail.com>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+Basic global debounce algorithm. Used in 99% of keyboards at time of implementation
+When no state changes have occured for DEBOUNCE milliseconds, we push the state.
+*/
+#include "matrix.h"
+#include "timer.h"
+#include "quantum.h"
+#ifndef DEBOUNCE
+#    define DEBOUNCE 5
+#endif
+
+void        debounce_init(uint8_t num_rows) {}
+static bool debouncing = false;
+
+#if DEBOUNCE > 0
+static uint16_t debouncing_time;
+void            debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool changed) {
+    if (!debouncing) {
+        for (int i = 0; i < num_rows; i++) {
+            cooked[i] = raw[i];
+        }
+    }
+
+    if( changed ) {
+        debouncing      = true;
+        debouncing_time = timer_read();
+    }
+
+    if (debouncing && timer_elapsed(debouncing_time) > DEBOUNCE) {
+        debouncing = false;
+    }
+}
+#else  // no debouncing.
+void debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool changed) {
+    for (int i = 0; i < num_rows; i++) {
+        cooked[i] = raw[i];
+    }
+}
+#endif
+
+bool debounce_active(void) { return debouncing; }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Adds a new debounce algorithm called sym_eager_g.  This follows the naming conventions QMK sets out.  "Eager" means it updates the matrix as soon as a change happens and then prevents matrix update for some time after.  I also have it continuously update the matrix when not changing which seemed to help.

This change also applies the new algorithm to:

Redragon K556
Redragon K552 rev1
Redragon K552 rev2
AJAZZ AK33 rev1
AJAZZ AK33 rev2

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
