### PR TITLE
Disable RGB Lights when the computer goes to sleep/turns off

### DIFF
--- a/keyboards/redragon/k556/config.h
+++ b/keyboards/redragon/k556/config.h
@@ -39,6 +39,9 @@
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5
 
+/* Disable the RGB when the host computer goes to sleep */
+#define RGBLIGHT_SLEEP
+
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 //#define LOCKING_SUPPORT_ENABLE
 /* Locking resynchronize hack */


### PR DESCRIPTION
Based in info found https://beta.docs.qmk.fm/using-qmk/hardware-features/lighting/feature_rgblight , based on my own desire as well as https://discord.com/channels/805578807477534750/805582334643929098/840255992582635530

Disables RGB Lights when the computer is sleeping or off (when USB power is not turned off)