### PR TITLE
unified matrix: allow boards to use their pwm configs

### DIFF
--- a/drivers/sn32/matrix_sn32f248b.c
+++ b/drivers/sn32/matrix_sn32f248b.c
@@ -109,9 +109,13 @@ void matrix_init(void) {
 
     // Enable Timer Clock
     SN_SYS1->AHBCLKEN_b.CT16B1CLKEN = 1;
-
+#ifndef SN32_CUSTOM_PFPA
     // PFPA - Map all PWM outputs to their PWM A pins
     SN_PFPA->CT16B1 = 0x00000000;
+#else
+    // PFPA - Map PWM outputs to their custom pins
+    SN_PFPA->CT16B1 = SN32_CUSTOM_PFPA;
+#endif
 
     pwm_en_msk = 0;
     

--- a/keyboards/keychron/k4/rules.mk
+++ b/keyboards/keychron/k4/rules.mk
@@ -31,6 +31,10 @@ ARMV = 6
 # BOOTLOADER = flash
 SN32_BOOTLOADER_ADDRESS = 0x1FFF0301
 
+# Custom PFPA assignment
+# PWM0-2 is B for the k4
+SN32_CUSTOM_PFPA = 0x00000007
+
 OPT_DEFS = -O2
 
 # Options to pass to dfu-util when flashing


### PR DESCRIPTION
## Description

Just add the pfpa config you need for the board as in the example
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
