### PR TITLE
[Redragon K530] Add Magic FN feature from stock FW

### DIFF
--- a/keyboards/redragon/k530/config.h
+++ b/keyboards/redragon/k530/config.h
@@ -39,6 +39,9 @@
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5
 
+/* Per-key tapping term, for use with Magic FN */
+#define TAPPING_TERM_PER_KEY
+
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 //#define LOCKING_SUPPORT_ENABLE
 /* Locking resynchronize hack */

--- a/keyboards/redragon/k530/keymaps/default/keymap.c
+++ b/keyboards/redragon/k530/keymaps/default/keymap.c
@@ -26,17 +26,26 @@ enum layer_names {
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    /*  Row:        0           1           2           3         4           5        6        7           8           9           10          11          12          13       */
-    [_BASE] = { {   KC_ESC,     KC_1,       KC_2,       KC_3,     KC_4,       KC_5,    KC_6,    KC_7,       KC_8,       KC_9,       KC_0,       KC_MINS,    KC_EQL,     KC_BSPC, },
-                {   KC_TAB,     KC_Q,       KC_W,       KC_E,     KC_R,       KC_T,    KC_Y,    KC_U,       KC_I,       KC_O,       KC_P,       KC_LBRC,    KC_RBRC,    KC_BSLS, },
-                {   KC_CAPS,    KC_A,       KC_S,       KC_D,     KC_F,       KC_G,    KC_H,    KC_J,       KC_K,       KC_L,       KC_SCLN,    KC_QUOT,    KC_NO,      KC_ENT,  },
-                {   KC_LSFT,    KC_NO,      KC_Z,       KC_X,     KC_C,       KC_V,    KC_B,    KC_N,       KC_M,       KC_COMM,    KC_DOT,     KC_SLSH,    KC_NO,      KC_RSFT, },
-                {   KC_LCTL,    KC_LGUI,    KC_LALT,    KC_NO,    KC_NO,      KC_NO,   KC_SPC,  KC_NO,      KC_NO,      KC_RALT,    MO(_FN),    KC_NO,      KC_APP,     KC_RCTL, },
+    /*  Row:        0                1           2           3         4           5        6        7           8           9           10          11          12          13       */
+    [_BASE] = { {   KC_ESC,          KC_1,       KC_2,       KC_3,     KC_4,       KC_5,    KC_6,    KC_7,       KC_8,       KC_9,       KC_0,       KC_MINS,    KC_EQL,     KC_BSPC, },
+                {   KC_TAB,          KC_Q,       KC_W,       KC_E,     KC_R,       KC_T,    KC_Y,    KC_U,       KC_I,       KC_O,       KC_P,       KC_LBRC,    KC_RBRC,    KC_BSLS, },
+                {   LT(_FN,KC_CAPS), KC_A,       KC_S,       KC_D,     KC_F,       KC_G,    KC_H,    KC_J,       KC_K,       KC_L,       KC_SCLN,    KC_QUOT,    KC_NO,      KC_ENT,  },
+                {   KC_LSFT,         KC_NO,      KC_Z,       KC_X,     KC_C,       KC_V,    KC_B,    KC_N,       KC_M,       KC_COMM,    KC_DOT,     KC_SLSH,    KC_NO,      KC_RSFT, },
+                {   KC_LCTL,         KC_LGUI,    KC_LALT,    KC_NO,    KC_NO,      KC_NO,   KC_SPC,  KC_NO,      KC_NO,      KC_RALT,    MO(_FN),    KC_NO,      KC_APP,     KC_RCTL, },
               },
-    [_FN]   = { {   KC_GRV,     KC_F1,      KC_F2,      KC_F3,    KC_F4,      KC_F5,   KC_F6,   KC_F7,      KC_F8,      KC_F9,      KC_F10,     KC_F11,     KC_F12,     _______, },
-                {   _______,    _______,    KC_UP,      _______,  _______,    _______, _______, _______,    _______,    _______,    KC_PSCR,    KC_HOME,    KC_END,     _______, },
-                {   _______,    KC_LEFT,    KC_DOWN,    KC_RIGHT, _______,    _______, _______, _______,    _______,    _______,    KC_PGUP,    KC_PGDN,    _______,    _______, },
-                {   _______,    _______,    _______,    _______,  _______,    _______, _______, _______,    _______,    _______,    KC_INS,     KC_DEL,     _______,    _______, },
-                {   _______,    _______,    _______,    _______,  _______,    _______, _______, _______,    _______,    _______,    _______,    _______,    _______,    RESET,   },
+    [_FN]   = { {   KC_GRV,          KC_F1,      KC_F2,      KC_F3,    KC_F4,      KC_F5,   KC_F6,   KC_F7,      KC_F8,      KC_F9,      KC_F10,     KC_F11,     KC_F12,     _______, },
+                {   _______,         _______,    KC_UP,      _______,  _______,    _______, _______, _______,    _______,    _______,    KC_PSCR,    KC_HOME,    KC_END,     _______, },
+                {   _______,         KC_LEFT,    KC_DOWN,    KC_RIGHT, _______,    _______, _______, _______,    _______,    _______,    KC_PGUP,    KC_PGDN,    _______,    _______, },
+                {   _______,         _______,    _______,    _______,  _______,    _______, _______, _______,    _______,    _______,    KC_INS,     KC_DEL,     _______,    _______, },
+                {   _______,         _______,    _______,    _______,  _______,    _______, _______, _______,    _______,    _______,    _______,    _______,    _______,    RESET,   },
              }
 };
+
+uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case LT(_FN,KC_CAPS):
+            return 2000; // 2 seconds, same as stock firmware
+        default:
+            return TAPPING_TERM;
+    }
+}


### PR DESCRIPTION
Added the ability to hold down Caps Lock for 2000ms to enable FN layer until released, mirroring the feature from the stock firmware of the K530. Tested on my keyboard, seemed to work without any issues. 

Please do let me know if I did something wrong, as this is my first PR here, and it would be appreciated.