### PR TITLE
[Keychron C1] Increase mac base layer index to make space for win overlay layers

### DIFF
--- a/keyboards/keychron/c1/c1.c
+++ b/keyboards/keychron/c1/c1.c
@@ -30,7 +30,7 @@ static void mode_leds_update(void){
 void dip_switch_update_user(uint8_t index, bool active){
     if(index == 0) {
         if(active) { // Mac mode
-            layer_move(2);
+            layer_move(8);
         } else { // Windows mode
             layer_move(0);
         }

--- a/keyboards/keychron/c1/keymaps/default/keymap.c
+++ b/keyboards/keychron/c1/keymaps/default/keymap.c
@@ -23,8 +23,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 enum layer_names {
     WIN_BASE    = 0,
     WIN_FN      = 1,
-    MAC_BASE    = 2,
-    MAC_FN      = 3,
+    MAC_BASE    = 8,
+    MAC_FN      = 9,
 };
 
 enum custom_keycodes {

--- a/keyboards/keychron/c1/keymaps/default/keymap.c
+++ b/keyboards/keychron/c1/keymaps/default/keymap.c
@@ -60,7 +60,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     +-------------------------------------------------------------------------------------------+
     */
 
-    [0] = { // Windows base layout
+    [WIN_BASE] = { // Windows base layout
         /*  0         1         2         3         4         5         6         7         8         9         10        11        12        13        14        15        16     */
         {   KC_ESC,   KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_F12,   KC_PSCR,  KC_CRTN,  RGB_MOD },
         {   KC_GRV,   KC_1,     KC_2,     KC_3,     KC_4,     KC_5,     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     KC_MINS,  KC_EQL,   KC_BSPC,  KC_INS,   KC_HOME,  KC_PGUP },
@@ -70,7 +70,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         {   KC_LCTL,  KC_LGUI,  KC_LALT,  KC_NO,    KC_NO,    KC_NO,    KC_SPC,   KC_NO,    KC_NO,    KC_NO,    KC_RALT,  KC_RGUI,  MO(1),    KC_RCTL,  KC_LEFT,  KC_DOWN,  KC_RGHT }
     },
 
-    [1] = { // Windows Fn overlay
+    [WIN_FN] = { // Windows Fn overlay
         /*  0         1         2         3         4         5         6         7         8         9         10        11        12        13        14        15        16     */
         {   RESET,    KC_BRID,  KC_BRIU,  KC_TASK,  KC_FLXP,  RGB_VAD,  RGB_VAI,  KC_MPRV,  KC_MPLY,  KC_MNXT,  KC_MUTE,  KC_VOLD,  KC_VOLU,  KC_NO,    KC_SNIP,  _______,  RGB_TOG },
         {   _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______ },
@@ -96,7 +96,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     +-------------------------------------------------------------------------------------------+
     */
 
-    [2] = { // Mac base layout
+    [MAC_BASE] = { // Mac base layout
         /*  0         1         2         3         4         5         6         7         8         9         10        11        12        13        14        15        16     */
         {   KC_ESC,   KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_NO,    KC_MSCR,  KC_SIRI,  RGB_MOD },
         {   KC_GRV,   KC_1,     KC_2,     KC_3,     KC_4,     KC_5,     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     KC_MINS,  KC_EQL,   KC_BSPC,  KC_INS,   KC_HOME,  KC_PGUP },
@@ -106,7 +106,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         {   KC_LCTL,  KC_LALT,  KC_LGUI,  KC_NO,    KC_NO,    KC_NO,    KC_SPC,   KC_NO,    KC_NO,    KC_NO,    KC_RGUI,  KC_RALT,  MO(3),    KC_RCTL,  KC_LEFT,  KC_DOWN,  KC_RGHT }
     },
 
-    [3] = { // Mac Fn overlay
+    [MAC_FN] = { // Mac Fn overlay
         /*  0         1         2         3         4         5         6         7         8         9         10        11        12        13        14        15        16     */
         {   RESET,    KC_BRID,  KC_BRIU,  KC_MSSN,  KC_FIND,  RGB_VAD,  RGB_VAI,  KC_MPRV,  KC_MPLY,  KC_MNXT,  KC_MUTE,  KC_VOLD,  KC_VOLU,  _______,  KC_MSNP,  _______,  RGB_TOG },
         {   _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______ },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
PR #108 moved the code to toggle layers with the dip switch out of `keymap.c` though the mac base layer has index 2. In this way there is no space for further win overlay layers that the user may want to define in a custom `keymap.c`. This PR increases the index of the mac base layer to fix the problem.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
