### PR TITLE
sleep led: sn32: don't override mode stored in eeprom

### DIFF
--- a/tmk_core/common/chibios/sleep_led.c
+++ b/tmk_core/common/chibios/sleep_led.c
@@ -216,19 +216,19 @@ void sleep_led_enable(void) {
     current_mode = rgb_matrix_get_mode();
     current_state = rgb_matrix_is_enabled();
     if (SLEEP_LED_MODE_ANIMATION == RGB_MATRIX_NONE) {
-        rgb_matrix_disable();
+        rgb_matrix_disable_noeeprom();
     }
     else {
-        rgb_matrix_mode(SLEEP_LED_MODE_ANIMATION);
+        rgb_matrix_mode_noeeprom(SLEEP_LED_MODE_ANIMATION);
     }
 }
 
 void sleep_led_disable(void) {
     if (current_state != rgb_matrix_is_enabled()) {
-        rgb_matrix_enable();
+        rgb_matrix_enable_noeeprom();
     }
     if (current_mode != rgb_matrix_get_mode()) {
-        rgb_matrix_mode(current_mode);
+        rgb_matrix_mode_noeeprom(current_mode);
     }
 }
 


### PR DESCRIPTION
This takes care of the bug where upon resuming from sleep state the rgb effect would stay as breathing.
Now it reverts back to the selected effect stored in eeprom.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
