### PR TITLE
Making compile firmware action fail

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -2,13 +2,6 @@ name: Compile Firmware
 
 on:
   push:
-    branches:
-    - sn32
-    - sn32_openrgb
-  pull_request:
-    branches:
-    - sn32
-    - sn32_openrgb
 
 jobs:
   Build:

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -2,6 +2,13 @@ name: Compile Firmware
 
 on:
   push:
+    branches:
+    - sn32
+    - sn32_openrgb
+  pull_request:
+    branches:
+    - sn32
+    - sn32_openrgb
 
 jobs:
   Build:

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -19,6 +19,7 @@ jobs:
       run: python3 bin/build_all.py
 
     - uses: actions/upload-artifact@v2
+      if: ${{ always() }}
       with:
         name: Pre-Compiled Firmware
         path: '*.bin'

--- a/bin/build_all.py
+++ b/bin/build_all.py
@@ -32,7 +32,7 @@ BOARDS = [
 
 error = False
 for kb in BOARDS:
-    if subprocess.run(f"bin/qmk compile -kb {kb} -km all -j{os.cpu_count()}", shell=True).returncode != 0:
+    if subprocess.run(f"qmk compile -kb {kb} -km all -j{os.cpu_count()}", shell=True).returncode != 0:
         error = True
 if error:
     sys.exit(1)

--- a/bin/build_all.py
+++ b/bin/build_all.py
@@ -1,5 +1,6 @@
 import subprocess
 import os
+import sys
 
 BOARDS = [
     'redragon/k552/rev1',
@@ -29,5 +30,9 @@ BOARDS = [
     'gmmk/full/rev3',
     'marvo/kg938']
 
+error = False
 for kb in BOARDS:
-    subprocess.run(f"bin/qmk compile -kb {kb} -km all -j{os.cpu_count()}", shell=True)
+    if subprocess.run(f"bin/qmk compile -kb {kb} -km all -j{os.cpu_count()}", shell=True).returncode != 0:
+        error = True
+if error:
+    sys.exit(1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->


## Description

Now the compile firmware action will fail if a keyboard or any of it's keymaps fail to compile.  Other keyboard firmwares will still be uploaded as artifacts, regardless of whether or not the build fails.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #155 

