### PR TITLE
Fix nightly.link links

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -36,3 +36,9 @@ jobs:
       with:
         name: Pre-Compiled Firmware (${{ steps.vars.outputs.branch }}-${{ steps.vars.outputs.sha_short }})
         path: '*.bin'
+        
+    - uses: actions/upload-artifact@v2
+      if: ${{ always() }}
+      with:
+        name: Pre-Compiled Firmware
+        path: '*.bin'


### PR DESCRIPTION
## Description

#163 Broke the nighty.link download links that are pinned in the #sonixqmk channel on discord. 
This should make them work again.
<!--- Describe your changes in detail here. -->