### PR TITLE
sn32 shared matrix: update all channels per row

### DIFF
--- a/drivers/sn32/rgb_matrix_sn32f248b.c
+++ b/drivers/sn32/rgb_matrix_sn32f248b.c
@@ -328,7 +328,7 @@ void rgb_callback(PWMDriver *pwmp) {
     current_led_row = (current_led_row + LED_MATRIX_ROW_CHANNELS);
     if(current_led_row >= LED_MATRIX_ROWS_HW) current_led_row = 0;
     // Advance to the next key matrix row
-    if(current_led_row % LED_MATRIX_ROW_CHANNELS == 2) row_idx++;
+    if(current_led_row % LED_MATRIX_ROW_CHANNELS == 0) row_idx++;
     if(row_idx >= LED_MATRIX_ROWS) row_idx = 0;
     chSysLockFromISR();
     // Disable LED output before scanning the key matrix


### PR DESCRIPTION
Attempt to further speedup the rgb matrix scan rate. Instead of 1 channel per row scan, do all 3

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
