### PR TITLE
sn32: 24x/B: enable some chibios opts to fix malloc/rand crashes

### DIFF
--- a/platforms/chibios/boards/SN_SN32F240/configs/chconf.h
+++ b/platforms/chibios/boards/SN_SN32F240/configs/chconf.h
@@ -338,7 +338,7 @@
  * @note    The default is @p TRUE.
  */
 #if !defined(CH_CFG_USE_MEMCORE)
-#define CH_CFG_USE_MEMCORE                  FALSE
+#define CH_CFG_USE_MEMCORE                  TRUE
 #endif
 
 /**

--- a/platforms/chibios/boards/SN_SN32F240/configs/chconf.h
+++ b/platforms/chibios/boards/SN_SN32F240/configs/chconf.h
@@ -367,7 +367,7 @@
  * @note    Mutexes are recommended.
  */
 #if !defined(CH_CFG_USE_HEAP)
-#define CH_CFG_USE_HEAP                     FALSE
+#define CH_CFG_USE_HEAP                     TRUE
 #endif
 
 /**

--- a/platforms/chibios/boards/SN_SN32F240/configs/chconf.h
+++ b/platforms/chibios/boards/SN_SN32F240/configs/chconf.h
@@ -378,7 +378,7 @@
  * @note    The default is @p TRUE.
  */
 #if !defined(CH_CFG_USE_MEMPOOLS)
-#define CH_CFG_USE_MEMPOOLS                 FALSE
+#define CH_CFG_USE_MEMPOOLS                 TRUE
 #endif
 
 /**

--- a/platforms/chibios/boards/SN_SN32F240/configs/chconf.h
+++ b/platforms/chibios/boards/SN_SN32F240/configs/chconf.h
@@ -327,7 +327,7 @@
  * @note    Requires @p CH_CFG_USE_SEMAPHORES.
  */
 #if !defined(CH_CFG_USE_MAILBOXES)
-#define CH_CFG_USE_MAILBOXES                FALSE
+#define CH_CFG_USE_MAILBOXES                TRUE
 #endif
 
 /**

--- a/platforms/chibios/boards/SN_SN32F240B/configs/chconf.h
+++ b/platforms/chibios/boards/SN_SN32F240B/configs/chconf.h
@@ -338,7 +338,7 @@
  * @note    The default is @p TRUE.
  */
 #if !defined(CH_CFG_USE_MEMCORE)
-#define CH_CFG_USE_MEMCORE                  FALSE
+#define CH_CFG_USE_MEMCORE                  TRUE
 #endif
 
 /**

--- a/platforms/chibios/boards/SN_SN32F240B/configs/chconf.h
+++ b/platforms/chibios/boards/SN_SN32F240B/configs/chconf.h
@@ -367,7 +367,7 @@
  * @note    Mutexes are recommended.
  */
 #if !defined(CH_CFG_USE_HEAP)
-#define CH_CFG_USE_HEAP                     FALSE
+#define CH_CFG_USE_HEAP                     TRUE
 #endif
 
 /**

--- a/platforms/chibios/boards/SN_SN32F240B/configs/chconf.h
+++ b/platforms/chibios/boards/SN_SN32F240B/configs/chconf.h
@@ -378,7 +378,7 @@
  * @note    The default is @p TRUE.
  */
 #if !defined(CH_CFG_USE_MEMPOOLS)
-#define CH_CFG_USE_MEMPOOLS                 FALSE
+#define CH_CFG_USE_MEMPOOLS                 TRUE
 #endif
 
 /**

--- a/platforms/chibios/boards/SN_SN32F240B/configs/chconf.h
+++ b/platforms/chibios/boards/SN_SN32F240B/configs/chconf.h
@@ -327,7 +327,7 @@
  * @note    Requires @p CH_CFG_USE_SEMAPHORES.
  */
 #if !defined(CH_CFG_USE_MAILBOXES)
-#define CH_CFG_USE_MAILBOXES                FALSE
+#define CH_CFG_USE_MAILBOXES                TRUE
 #endif
 
 /**


### PR DESCRIPTION
We've been having issues with some rgb effects and pretty much anything using rand(). This should fix it
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
