### PR TITLE
Remove MATRIX_KEY_SAMPLE_DELAY for optical sn32f24xx keyboards

### DIFF
--- a/drivers/led/sn32/matrix_sn32f24xx.c
+++ b/drivers/led/sn32/matrix_sn32f24xx.c
@@ -35,9 +35,6 @@ Ported to QMK by Stephen Peery <https://github.com/smp4488/>
 #ifndef PRESSED_KEY_PIN_STATE
 #    define PRESSED_KEY_PIN_STATE 1
 #endif
-#ifndef MATRIX_KEY_SAMPLE_DELAY
-#    define MATRIX_KEY_SAMPLE_DELAY 2000
-#endif
 #endif
 
 #ifndef PRESSED_KEY_PIN_STATE


### PR DESCRIPTION
Fix optical keyboard delay for SN32F24XX based keyboards

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Remove MATRIX_KEY_SAMPLE_DELAY for optical keyboards since its not needed anymore and makes the leds flicker.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
