### PR TITLE
Fix SRC path to matrix drivers for Keychron K6

### DIFF
--- a/keyboards/keychron/k6/rgb/rules.mk
+++ b/keyboards/keychron/k6/rgb/rules.mk
@@ -1,5 +1,5 @@
 # project specific files
-SRC = ../../../../drivers/led/sn32/matrix_sn32f24xx.c
+SRC = ../../../drivers/led/sn32/matrix_sn32f24xx.c
 SRC += config_led.c
 
 # MCU name


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Noticed while trying to build for my K6 that this path was different to all the other keychron K* variants and was failing to build for me on windows 10. Perhaps it was missed in a refactor?

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Compiling for Keychron K6 works now

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
