### PR TITLE
openrgb: Set internal mode to direct mode when direct mode is requested

### DIFF
--- a/quantum/openrgb.c
+++ b/quantum/openrgb.c
@@ -202,9 +202,11 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
             break;
         case OPENRGB_DIRECT_MODE_SET_SINGLE_LED:
             openrgb_direct_mode_set_single_led(data);
+            rgb_matrix_mode(RGB_MATRIX_OPENRGB_DIRECT);
             break;
         case OPENRGB_DIRECT_MODE_SET_LEDS:
             openrgb_direct_mode_set_leds(data);
+            rgb_matrix_mode(RGB_MATRIX_OPENRGB_DIRECT);
             break;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

When using OpenRGB to set direct mode LEDs, also set the internal state of the firmware to direct mode.

@Kasper24
Since you made the original code, would you mind checking if that is correct?


<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This is needed, because otherwise the firmware will keep the current operating mode. Without this fix applied, direct mode is not working at all for us.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
