### PR TITLE
Fixed out of bounds array access in SN32F24XB RGB matrix

### DIFF
--- a/drivers/led/sn32/rgb_matrix_sn32f24xb.c
+++ b/drivers/led/sn32/rgb_matrix_sn32f24xb.c
@@ -115,7 +115,7 @@ void rgb_ch_ctrl(PWMConfig *cfg) {
                 cfg->channels[1].mode = PWM_OUTPUT_ACTIVE_LOW;
                 chan_col_order[i] = 1;
                 break;
-            
+
             case B10:
                 cfg->channels[2].pfpamsk = 1;
             case A2:
@@ -300,23 +300,26 @@ void update_pwm_channels(PWMDriver *pwmp) {
             matrix_scan_keys(raw_matrix,col_idx);
         #endif
         uint8_t led_index = g_led_config.matrix_co[row_idx][col_idx];
-        // Check if we need to enable RGB output
-        if (led_state[led_index].b != 0) enable_pwm |= true;
-        if (led_state[led_index].g != 0) enable_pwm |= true;
-        if (led_state[led_index].r != 0) enable_pwm |= true;
-        // Update matching RGB channel PWM configuration
-        switch(current_row % LED_MATRIX_ROW_CHANNELS) {
-        case 0:
-                if(enable_pwm) pwmEnableChannelI(pwmp,chan_col_order[col_idx],led_state[led_index].b);
-            break;
-        case 1:
-                if(enable_pwm) pwmEnableChannelI(pwmp,chan_col_order[col_idx],led_state[led_index].g);
-            break;
-        case 2:
-                if(enable_pwm) pwmEnableChannelI(pwmp,chan_col_order[col_idx],led_state[led_index].r);
-            break;
-        default:
-            ;
+        // Check if led index is within array bounds
+        if (led_index < DRIVER_LED_TOTAL) {
+            // Check if we need to enable RGB output
+            if (led_state[led_index].b != 0) enable_pwm |= true;
+            if (led_state[led_index].g != 0) enable_pwm |= true;
+            if (led_state[led_index].r != 0) enable_pwm |= true;
+            // Update matching RGB channel PWM configuration
+            switch(current_row % LED_MATRIX_ROW_CHANNELS) {
+            case 0:
+                    if(enable_pwm) pwmEnableChannelI(pwmp,chan_col_order[col_idx],led_state[led_index].b);
+                break;
+            case 1:
+                    if(enable_pwm) pwmEnableChannelI(pwmp,chan_col_order[col_idx],led_state[led_index].g);
+                break;
+            case 2:
+                    if(enable_pwm) pwmEnableChannelI(pwmp,chan_col_order[col_idx],led_state[led_index].r);
+                break;
+            default:
+                ;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixed out of bounds array access in SN32F24XB RGB matrix

## Description

We get led_index from g_led_config.matrix_co, this is the first part in the g_led_config.
When a LED is not present in g_led_config.matrix_co it is marked with NO_LED which has the value 255.
Now we use led_index as index on array led_state, but this array is defined with DRIVER_LED_TOTAL elements, which is typically smaller than 255.
This is a typical array out of bounds access, that would most likely segfault on x86. But ARM doesn't care and just reads whatever is in memory.

## Types of Changes
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation
