### PR TITLE
Non WL driver for SN32

### DIFF
--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -244,6 +244,9 @@ else
         # Teensy EEPROM implementations
         OPT_DEFS += -DEEPROM_KINETIS_FLEXRAM
         SRC += eeprom_kinetis_flexram.c
+      else ifneq ($(filter $(MCU_SERIES),SN32F240B SN32F260),)
+        OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_SN32_FLASH_EMULATED
+        SRC += eeprom_driver.c eeprom_sn32.c
       else
         # Fall back to transient, i.e. non-persistent
         OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_TRANSIENT

--- a/platforms/chibios/drivers/eeprom/eeprom_sn32.c
+++ b/platforms/chibios/drivers/eeprom/eeprom_sn32.c
@@ -1,0 +1,164 @@
+/*
+ * This software is experimental and a work in progress.
+ * Under no circumstances should these files be used in relation to any critical system(s).
+ * Use of these files is at your own risk.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * This files are free to use from http://engsta.com/stm32-flash-memory-eeprom-emulator/ by
+ * Artur F.
+ *
+ * Modifications for QMK and STM32F303 by Yiancar
+ * Adapted for SONIX chips by dexter93 and gloryhzw
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "debug.h"
+#include "Flash.h"
+#include "eeprom_sn32.h"
+
+/*****************************************************************************
+ * Allows to use the internal flash to store non volatile data. To initialize
+ * the functionality use the EEPROM_Init() function. Be sure that by reprogramming
+ * of the controller just affected pages will be deleted. In other case the non
+ * volatile data will be lost.
+ ******************************************************************************/
+#include "eeprom_sn32_defs.h"
+#if !defined(FEE_PAGE_SIZE) || !defined(FEE_TOTAL_PAGES) || !defined(FEE_DENSITY_PAGES) || !defined(FEE_MCU_FLASH_SIZE) || !defined(FEE_PAGE_BASE_ADDRESS)
+#    error "not implemented."
+#endif
+
+#define FEE_DENSITY_BYTES (FEE_PAGE_SIZE * FEE_DENSITY_PAGES - 1)
+#define FEE_LAST_PAGE_ADDRESS (FEE_PAGE_BASE_ADDRESS + (FEE_PAGE_SIZE * FEE_DENSITY_PAGES))
+#define FEE_ADDR_OFFSET(Address) (Address)
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Functions -----------------------------------------------------------------*/
+/*
+ * Debug print utils
+ */
+
+// #define DEBUG_EEPROM_OUTPUT
+
+#if defined(DEBUG_EEPROM_OUTPUT)
+
+#    define debug_eeprom debug_enable
+#    define eeprom_println(s) println(s)
+#    define eeprom_printf(fmt, ...) xprintf(fmt, ##__VA_ARGS__);
+
+#else /* NO_DEBUG */
+
+#    define debug_eeprom false
+#    define eeprom_println(s)
+#    define eeprom_printf(fmt, ...)
+
+#endif /* NO_DEBUG */
+
+/*****************************************************************************
+ *  Delete Flash Space used for user Data, deletes the whole space between
+ *  RW_PAGE_BASE_ADDRESS and the last uC Flash Page
+ ******************************************************************************/
+uint16_t EEPROM_Init(void) {
+    // Clear Flags
+    // SN_FLASH->STATUS &= ~FLASH_PGERR
+    if (debug_eeprom) {
+        println("EEPROM_Init");
+    }
+
+    return FEE_DENSITY_BYTES;
+}
+
+/*****************************************************************************
+ *  Erase the whole reserved Flash Space used for user Data
+ ******************************************************************************/
+void EEPROM_Erase(void) {
+    int page_num = 0;
+
+    // delete all pages from specified start page to the last page
+    do {
+        eeprom_println("EEPROM_Erase");
+        FLASH_EraseSector(FEE_PAGE_BASE_ADDRESS + (page_num * FEE_PAGE_SIZE));
+        page_num++;
+    } while (page_num < FEE_DENSITY_PAGES);
+}
+
+/*****************************************************************************
+ *  Writes data to flash on specified address.
+ *******************************************************************************/
+uint8_t EEPROM_WriteDataByte(uint16_t Address, uint8_t DataByte) {
+    FLASH_Status FlashStatus = FLASH_OKAY;
+
+    /* if the address is out-of-bounds, do nothing */
+    if (Address > FEE_DENSITY_BYTES) {
+        eeprom_printf("EEPROM_WriteDataByte(0x%04x, 0x%02x) [BAD ADDRESS]\n", Address, DataByte);
+        return FLASH_FAIL;
+    }
+    uint32_t addr = FEE_PAGE_BASE_ADDRESS + FEE_ADDR_OFFSET(Address);
+
+    /* if the value is the same, don't bother writing it */
+    if (DataByte == *(__IO uint8_t *)addr) {
+        eeprom_printf("EEPROM_WriteDataByte(0x%04x, 0x%02x) [SKIP SAME]\n", Address, DataByte);
+        return FLASH_OKAY;
+    }
+
+    // update the data byte aligned in a 32-bit dword
+    uint32_t value = *((uint32_t *)(addr & 0xFFFFFFFC));
+    uint8_t *v8    = (uint8_t *)&value;
+    v8[addr & 3]   = DataByte;
+
+    // program the 32-bit dword
+    eeprom_printf("FLASH_ProgramDWord(0x%08x, 0x%04x) [DIRECT]\n", Address, value);
+    FlashStatus = FLASH_ProgramDWord(addr & 0xFFFFFFFC, value);
+
+    return FlashStatus;
+}
+
+/*****************************************************************************
+ *  Read data from a specified address.
+ *******************************************************************************/
+uint8_t EEPROM_ReadDataByte(uint16_t Address) {
+    uint8_t DataByte = 0xFF;
+
+    if (Address <= FEE_DENSITY_BYTES) {
+        // Get Byte from specified address
+        DataByte = (*(__IO uint8_t *)(FEE_PAGE_BASE_ADDRESS + FEE_ADDR_OFFSET(Address)));
+    }
+
+    eeprom_printf("EEPROM_ReadDataByte(0x%04x): 0x%02x\n", Address, DataByte);
+
+    return DataByte;
+}
+
+/*****************************************************************************
+ *  Bind to eeprom_driver.c
+ *******************************************************************************/
+void eeprom_driver_init(void) {
+    EEPROM_Init();
+}
+
+void eeprom_driver_erase(void) {
+    EEPROM_Erase();
+}
+
+void eeprom_read_block(void *buf, const void *addr, size_t len) {
+    const uint8_t *p    = (const uint8_t *)addr;
+    uint8_t *      dest = (uint8_t *)buf;
+    while (len--) {
+        *dest++ = EEPROM_ReadDataByte((uint16_t)(uint32_t)(p++));
+    }
+}
+
+void eeprom_write_block(const void *buf, void *addr, size_t len) {
+    uint8_t *      p   = (uint8_t *)addr;
+    const uint8_t *src = (const uint8_t *)buf;
+    while (len--) {
+        EEPROM_WriteDataByte((uint16_t)(uint32_t)p++, *src++);
+    }
+}

--- a/platforms/chibios/drivers/eeprom/eeprom_sn32.h
+++ b/platforms/chibios/drivers/eeprom/eeprom_sn32.h
@@ -1,0 +1,30 @@
+/*
+ * This software is experimental and a work in progress.
+ * Under no circumstances should these files be used in relation to any critical system(s).
+ * Use of these files is at your own risk.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * This files are free to use from http://engsta.com/stm32-flash-memory-eeprom-emulator/ by
+ * Artur F.
+ *
+ * Modifications for QMK and SONIX chips by smplman and dexter93
+ *
+ * This library assumes 8-bit data locations. To add a new MCU, please provide the flash
+ * page size and the total flash size in Kb. The number of available pages must be a multiple
+ * of 2. Only half of the pages account for the total EEPROM size.
+ * This library also assumes that the pages are not used by the firmware.
+ */
+
+#pragma once
+
+// Use this function to initialize the functionality
+uint16_t EEPROM_Init(void);
+void     EEPROM_Erase(void);
+uint8_t  EEPROM_WriteDataByte(uint16_t Address, uint8_t DataByte);
+uint8_t  EEPROM_ReadDataByte(uint16_t Address);

--- a/platforms/chibios/drivers/eeprom/eeprom_sn32_defs.h
+++ b/platforms/chibios/drivers/eeprom/eeprom_sn32_defs.h
@@ -1,0 +1,59 @@
+/* Copyright 2021 SonixQMK
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <hal.h>
+
+#if !defined(FEE_PAGE_SIZE) || !defined(FEE_TOTAL_PAGES) || !defined(FEE_DENSITY_PAGES)
+#    if defined(SN32F240B)
+#        ifndef FEE_PAGE_SIZE
+#            define FEE_PAGE_SIZE (uint16_t)0x0040 // Page size = 64bytes
+#        endif
+#        ifndef FEE_TOTAL_PAGES
+#            define FEE_TOTAL_PAGES 1024 // How many pages are available
+#        endif
+#        ifndef FEE_DENSITY_PAGES
+#            define FEE_DENSITY_PAGES 23 // How many pages are used as EEPROM
+#        endif
+#    elif defined(SN32F260)
+#        ifndef FEE_PAGE_SIZE
+#            define FEE_PAGE_SIZE (uint16_t)0x0040 // Page size = 64bytes
+#        endif
+#        ifndef FEE_TOTAL_PAGES
+#            define FEE_TOTAL_PAGES 480 // How many pages are available
+#        endif
+#        ifndef FEE_DENSITY_PAGES
+#            define FEE_DENSITY_PAGES 23 // How many pages are used as EEPROM
+#        endif
+#    endif
+#endif
+
+#if !defined(FEE_MCU_FLASH_SIZE)
+#    if defined(SN32F240B)
+#        define FEE_MCU_FLASH_SIZE 64 // Size in Kb
+#    elif defined(SN32F260)
+#        define FEE_MCU_FLASH_SIZE 30 // Size in Kb
+#    endif
+#endif
+
+/* Start of the emulated eeprom */
+#if !defined(FEE_PAGE_BASE_ADDRESS)
+#    if defined(SN32F240B) || defined(SN32F260)
+#        ifndef FEE_PAGE_BASE_ADDRESS
+#            define FEE_PAGE_BASE_ADDRESS ((uint32_t)(FEE_PAGE_SIZE * FEE_TOTAL_PAGES - ((FEE_DENSITY_PAGES + 1) * FEE_PAGE_SIZE))) // Guard the last page
+#        endif
+#    endif
+#endif

--- a/platforms/eeprom.h
+++ b/platforms/eeprom.h
@@ -47,6 +47,9 @@ void     eeprom_update_block(const void *__src, void *__dst, size_t __n);
 #elif defined(EEPROM_LEGACY_EMULATED_FLASH)
 #    include "eeprom_legacy_emulated_flash_defs.h"
 #    define TOTAL_EEPROM_BYTE_COUNT (FEE_DENSITY_BYTES)
+#elif defined(EEPROM_SN32_FLASH_EMULATED)
+#    include "eeprom_sn32_defs.h"
+#    define TOTAL_EEPROM_BYTE_COUNT (FEE_DENSITY_BYTES)
 #elif defined(EEPROM_SAMD)
 #    include "eeprom_samd.h"
 #    define TOTAL_EEPROM_BYTE_COUNT (EEPROM_SIZE)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

To use the WL driver, compile with:
```
EEPROM_DRIVER = wear_leveling
WEAR_LEVELING_DRIVER = sn32_flash
```

The non-WL driver gets picked up when no EEPROM driver is set.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
