### PR TITLE
Fix pin D4 not being activated on SM32F268F chips

### DIFF
--- a/drivers/led/sn32/led_matrix_sn32f26x.c
+++ b/drivers/led/sn32/led_matrix_sn32f26x.c
@@ -140,6 +140,10 @@ void led_ch_ctrl(void) {
                 chan_col_order[i] = 19;
                 break;
 
+            case D4:
+                chan_col_order[i] = 20;
+                break;
+
             case D5:
                 chan_col_order[i] = 21;
                 break;
@@ -260,8 +264,12 @@ static const PWMConfig pwmcfg = {
             [19] = {.mode = PWM_OUTPUT_ACTIVE_LOW},
 #else
             [19] = {.mode = PWM_OUTPUT_DISABLED},
-#endif /* Channel 20 is a dummy channel in 26x .*/
+#endif 
+#ifdef ACTIVATE_PWM_CHAN_20
+            [20] = {.mode = PWM_OUTPUT_ACTIVE_LOW},
+#else
             [20] = {.mode = PWM_OUTPUT_DISABLED},
+#endif 
 #ifdef ACTIVATE_PWM_CHAN_21
             [21] = {.mode = PWM_OUTPUT_ACTIVE_LOW},
 #else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Changed D4 to match all the other pins in /drivers/led/sn32/led_matrix_sn32f26x.c. This fixed the led's that use that pin on my Hcman h02 keyboard.
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
