### PR TITLE
Flip Mac and Windows layer order to correspond with the physical switch

### DIFF
--- a/keyboards/keychron/c2/rgb/keymaps/default/keymap.c
+++ b/keyboards/keychron/c2/rgb/keymaps/default/keymap.c
@@ -21,10 +21,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // Layer names don't all need to be of the same length, obviously, and you can also skip them
 // entirely and just use numbers.
 enum layer_names {
-    WIN_BASE    = 0,
-    WIN_FN      = 1,
-    MAC_BASE    = 2,
-    MAC_FN      = 3,
+    MAC_BASE    = 0,
+    MAC_FN      = 1,
+    WIN_BASE    = 2,
+    WIN_FN      = 3,
 };
 
 #define KC_TASK LGUI(KC_TAB)        // Task viewer

--- a/keyboards/keychron/c2/rgb/keymaps/default/keymap.c
+++ b/keyboards/keychron/c2/rgb/keymaps/default/keymap.c
@@ -62,7 +62,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         {   KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_LBRC,  KC_RBRC,  KC_BSLS,  KC_DEL,   KC_END,   KC_PGDN, KC_P7,   KC_P8,   KC_P9,   KC_PPLS },
         {   KC_CAPS,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,  KC_NO,    KC_ENT,   KC_NO,    KC_NO,    KC_NO,   KC_P4,   KC_P5,   KC_P6,   KC_NO   },
         {   KC_LSFT,  KC_NO,    KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  KC_NO,    KC_RSFT,  KC_NO,    KC_UP,    KC_NO,   KC_P1,   KC_P2,   KC_P3,   KC_PENT },
-        {   KC_LCTL,  KC_LGUI,  KC_LALT,  KC_NO,    KC_NO,    KC_NO,    KC_SPC,   KC_NO,    KC_NO,    KC_RALT,  KC_RGUI,  MO(1),    KC_NO,    KC_RCTL,  KC_LEFT,  KC_DOWN,  KC_RGHT, KC_NO,   KC_P0,   KC_PDOT, KC_NO   }
+        {   KC_LCTL,  KC_LGUI,  KC_LALT,  KC_NO,    KC_NO,    KC_NO,    KC_SPC,   KC_NO,    KC_NO,    KC_RALT,  KC_RGUI,  MO(3),    KC_NO,    KC_RCTL,  KC_LEFT,  KC_DOWN,  KC_RGHT, KC_NO,   KC_P0,   KC_PDOT, KC_NO   }
     },
 
     [WIN_FN] = { // Windows Fn overlay
@@ -100,7 +100,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         {   KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_LBRC,  KC_RBRC,  KC_BSLS,  KC_DEL,   KC_END,   KC_PGDN, KC_P7,   KC_P8,   KC_P9,   KC_PPLS },
         {   KC_CAPS,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,  KC_NO,    KC_ENT,   KC_NO,    KC_NO,    KC_NO,   KC_P4,   KC_P5,   KC_P6,   KC_NO   },
         {   KC_LSFT,  KC_NO,    KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  KC_NO,    KC_RSFT,  KC_NO,    KC_UP,    KC_NO,   KC_P1,   KC_P2,   KC_P3,   KC_PENT },
-        {   KC_LCTL,  KC_LALT,  KC_LGUI,  KC_NO,    KC_NO,    KC_NO,    KC_SPC,   KC_NO,    KC_NO,    KC_RGUI,  KC_RALT,  MO(3),    KC_NO,    KC_RCTL,  KC_LEFT,  KC_DOWN,  KC_RGHT, KC_NO,   KC_P0,   KC_PDOT, KC_NO   }
+        {   KC_LCTL,  KC_LALT,  KC_LGUI,  KC_NO,    KC_NO,    KC_NO,    KC_SPC,   KC_NO,    KC_NO,    KC_RGUI,  KC_RALT,  MO(1),    KC_NO,    KC_RCTL,  KC_LEFT,  KC_DOWN,  KC_RGHT, KC_NO,   KC_P0,   KC_PDOT, KC_NO   }
     },
 
     [MAC_FN] = { // Mac Fn overlay


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
The current C2 config is flipped, the correct config is layer 0 and 1 corresponding with the mac switch, and layer 2 and 3 corresponding to the windows switch

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
