### PR TITLE
sn32: remove HAS_ configs

### DIFF
--- a/platforms/chibios/boards/SN_SN32F240/board/board.mk
+++ b/platforms/chibios/boards/SN_SN32F240/board/board.mk
@@ -6,6 +6,8 @@ BOARDINC = $(CHIBIOS_CONTRIB)/os/hal/boards/SN_SN32F240
 
 # Optimize for speed
 OPT = 2
+# Shave some extra bytes
+OPT_DEFS += -DCRT1_AREAS_NUMBER=1
 
 # Shared variables
 ALLCSRC += $(BOARDSRC)

--- a/platforms/chibios/boards/SN_SN32F240/configs/mcuconf.h
+++ b/platforms/chibios/boards/SN_SN32F240/configs/mcuconf.h
@@ -39,23 +39,11 @@
 /*
  * CT driver system settings.
  */
-#define SN32_HAS_CT16B0 TRUE
-#define SN32_HAS_CT16B1 TRUE
-
-/*
- * SN driver system settings.
- */
-#define SN32_HAS_GPIOA TRUE
-#define SN32_HAS_GPIOB TRUE
-#define SN32_HAS_GPIOC TRUE
-#define SN32_HAS_GPIOD TRUE
-
+// Defaults are correct
 /*
  * USB driver system settings.
  */
-#define CRT1_AREAS_NUMBER 1
-#define PLATFORM_USB_USE_USB1 TRUE
-
+// Defaults are correct
 /*
  * Timer driver system settings.
  */

--- a/platforms/chibios/boards/SN_SN32F240B/configs/mcuconf.h
+++ b/platforms/chibios/boards/SN_SN32F240B/configs/mcuconf.h
@@ -39,27 +39,16 @@
 /*
  * CT driver system settings.
  */
-#define SN32_HAS_CT16B0 TRUE
-#define SN32_HAS_CT16B1 TRUE
+// Defaults are correct
 /*
  * PWM driver system settings.
  */
 #define SN32_PWM_USE_CT16B1 TRUE
 #define SN32_PWM_NO_RESET TRUE
 /*
- * SN driver system settings.
- */
-#define SN32_HAS_GPIOA TRUE
-#define SN32_HAS_GPIOB TRUE
-#define SN32_HAS_GPIOC TRUE
-#define SN32_HAS_GPIOD TRUE
-
-/*
  * USB driver system settings.
  */
-#define SN32_HAS_USB TRUE
-#define SN32_USB_USE_USB1 TRUE
-
+// Defaults are correct
 /*
  * System Clock settings.
  */

--- a/platforms/chibios/boards/SN_SN32F260/configs/mcuconf.h
+++ b/platforms/chibios/boards/SN_SN32F260/configs/mcuconf.h
@@ -40,26 +40,16 @@
 /*
  * CT driver system settings.
  */
-#define SN32_HAS_CT16B0 TRUE
-#define SN32_HAS_CT16B1 TRUE
+// Defaults are correct
 /*
  * PWM driver system settings.
  */
 #define SN32_PWM_USE_CT16B1 TRUE
 #define SN32_PWM_NO_RESET TRUE
 /*
- * SN driver system settings.
- */
-#define SN32_HAS_GPIOA TRUE
-#define SN32_HAS_GPIOB TRUE
-#define SN32_HAS_GPIOC TRUE
-#define SN32_HAS_GPIOD TRUE
-
-/*
  * USB driver system settings.
  */
-#define SN32_HAS_USB TRUE
-#define SN32_USB_USE_USB1 TRUE
+// Defaults are correct
 
 /*
  * System Clock settings.


### PR DESCRIPTION
we set them per chip in their respective registry in chibios level

see
https://github.com/ChibiOS/ChibiOS-Contrib/pull/377
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
