### PR TITLE
Get bootmagic working with shared sn32f24xb matrix

### DIFF
--- a/drivers/led/sn32/rgb_matrix_sn32f24xb.c
+++ b/drivers/led/sn32/rgb_matrix_sn32f24xb.c
@@ -548,6 +548,26 @@ void sn32f24xb_set_color_all(uint8_t r, uint8_t g, uint8_t b) {
     }
 }
 
+#if defined(SHARED_MATRIX) && defined(BOOTMAGIC_LITE)
+void matrix_init_kb(void) {
+    matrix_init_user();
+    // do a single scan of matrix before RGB is running, for bootmagic lite
+#if (DIODE_DIRECTION == COL2ROW)
+    for (uint8_t row_index = 0; row_index < ROWS_PER_HAND; row_index++) {
+        matrix_read_cols_on_row(shared_matrix, row_index);
+    }
+#elif (DIODE_DIRECTION == ROW2COL)
+    matrix_row_t row_shifter = MATRIX_ROW_SHIFTER;
+    for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++, row_shifter <<= 1) {
+        matrix_read_rows_on_col(shared_matrix, col_index, row_shifter);
+    }
+#else
+    #error "Shared matrix direct pins not supported!"
+#endif // DIODE_DIRECTION
+    matrix_scanned = true;
+}
+#endif
+
 bool matrix_scan_custom(matrix_row_t current_matrix[]) {
     if (!matrix_scanned) return false; // Nothing to process until we have the matrix scanned
 


### PR DESCRIPTION
## Description

Fix bootmagic lite when using sn32f24xb shared rgb/key matrix driver.

Bootmagic lite gets checked as early as possible -> after key matrix has been initialized but before other optional subystems like RGB are running.  Even if bootmagic check happened after rgb is initialized the actual scanning code runs at it's own pace based on timer interrupts, which makes it's usage during early init somewhat problematic. As a result bootmagic_lite doesn't work probably for most sonix keyboards using shared matrix and the corresponding driver.

This PR adds single manual key only scan to ensure there is meaningful data when the default bootmagic implementation reads it.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
