### PR TITLE
redragon/k552/v2/iso - fix led matrix and via build

### DIFF
--- a/keyboards/redragon/k552/v2/iso/keyboard.json
+++ b/keyboards/redragon/k552/v2/iso/keyboard.json
@@ -35,20 +35,7 @@
     "rgb_matrix": {
         "animations": {
             "alphas_mods" : true,
-            "band_pinwheel_sat" : true,
-            "band_pinwheel_val" : true,
-            "band_sat" : true,
-            "band_spiral_sat" : true,
-            "band_spiral_val" : true,
-            "band_val" : true,
             "breathing" : true,
-            "cycle_all" : true,
-            "cycle_left_right" : true,
-            "cycle_out_in" : true,
-            "cycle_out_in_dual" : true,
-            "cycle_pinwheel" : true,
-            "cycle_spiral" : true,
-            "cycle_up_down" : true,
             "digital_rain" : true,
             "dual_beacon" : true,
             "gradient_left_right" : true,
@@ -58,14 +45,10 @@
             "hue_wave" : true,
             "jellybean_raindrops" : true,
             "multisplash" : true,
-            "pixel_flow" : true,
-            "pixel_fractal" : true,
-            "pixel_rain" : true,
             "rainbow_beacon" : true,
             "rainbow_moving_chevron" : true,
             "rainbow_pinwheels" : true,
             "raindrops" : true,
-            "solid_multisplash" : true,
             "solid_reactive" : true,
             "solid_reactive_cross" : true,
             "solid_reactive_multicross" : true,
@@ -74,9 +57,7 @@
             "solid_reactive_nexus" : true,
             "solid_reactive_simple" : true,
             "solid_reactive_wide" : true,
-            "solid_splash" : true,
-            "splash" : true,
-            "typing_heatmap" : true
+            "solid_splash" : true
         },
         "driver": "sn32f2xx",
         "layout": [
@@ -86,10 +67,12 @@
             {"matrix": [0, 2], "flags": 4, "x": 42, "y": 0},
             {"matrix": [0, 3], "flags": 4, "x": 56, "y": 0},
             {"matrix": [0, 4], "flags": 4, "x": 70, "y": 0},
+
             {"matrix": [0, 5], "flags": 4, "x": 77, "y": 0},
             {"matrix": [0, 6], "flags": 4, "x": 91, "y": 0},
             {"matrix": [0, 7], "flags": 4, "x": 105, "y": 0},
             {"matrix": [0, 8], "flags": 4, "x": 119, "y": 0},
+
             {"matrix": [0, 9],  "flags": 4, "x": 140 , "y": 0},
             {"matrix": [0, 10], "flags": 4, "x": 154, "y": 0},
             {"matrix": [0, 11], "flags": 4, "x": 168, "y": 0},
@@ -131,7 +114,6 @@
             {"matrix": [2, 10], "flags": 4, "x": 147, "y": 29},
             {"matrix": [2, 11], "flags": 4, "x": 161, "y": 29},
             {"matrix": [2, 12], "flags": 4, "x": 175, "y": 29},
-            {"matrix": [2, 13], "flags": 4, "x": 193, "y": 35},
 
             {"matrix": [2, 14], "flags": 4, "x": 196, "y": 29},
             {"matrix": [2, 15], "flags": 4, "x": 210, "y": 29},
@@ -149,7 +131,8 @@
             {"matrix": [3, 9], "flags": 4, "x": 137, "y": 41},
             {"matrix": [3, 10], "flags": 4, "x": 151, "y": 41},
             {"matrix": [3, 11], "flags": 4, "x": 165, "y": 41},
-            {"matrix": [3, 13], "flags": 4, "x": 179, "y": 41},
+            {"matrix": [3, 12], "flags": 4, "x": 179, "y": 41},
+            {"matrix": [3, 13], "flags": 4, "x": 224, "y": 35},
 
             {"matrix": [4, 0], "flags": 4, "x": 1, "y": 52},
             {"matrix": [4, 2], "flags": 4, "x": 17, "y": 52},


### PR DESCRIPTION
* there is an actual difference between the keyboard an the led matrix so # was unlit because it was mapped to what was meant to be return fix the matrix (tested on my keyboard after having ignored this for months...)
* disable some effects to fix via build (too big with all effects enabled)

## Description
This fixes the unlit # key and via build (by disabling some matrix effects to make the firmware smaller).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ x] Bugfix
## Issues Fixed or Closed by This PR


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
