### PR TITLE
Handle UNSELECT_DRIVE_HIGH and SN32F2XX_PWM_OUTPUT_ACTIVE_HIGH

### DIFF
--- a/drivers/led/sn32f2xx.c
+++ b/drivers/led/sn32f2xx.c
@@ -440,7 +440,7 @@ static void shared_matrix_rgb_disable_output(void) {
         gpio_set_pin_input(led_col_pins[x]);
 #    endif // DIODE_DIRECTION != SN32F2XX_PWM_DIRECTION
         // Unselect all columns before scanning the key matrix
-#    if (SN32F2XX_RGB_OUTPUT_ACTIVE_LEVEL == SN32F2XX_RGB_OUTPUT_ACTIVE_LOW)
+#    if (SN32F2XX_RGB_OUTPUT_ACTIVE_LEVEL == SN32F2XX_RGB_OUTPUT_ACTIVE_LOW  || defined(MATRIX_UNSELECT_DRIVE_HIGH))
         gpio_write_pin_high(led_col_pins[x]);
 #    elif (SN32F2XX_RGB_OUTPUT_ACTIVE_LEVEL == SN32F2XX_RGB_OUTPUT_ACTIVE_HIGH)
         gpio_write_pin_low(led_col_pins[x]);
@@ -478,6 +478,13 @@ static void update_pwm_channels(PWMDriver *pwmp) {
         shared_matrix_scan_keys(shared_matrix, current_key_col, last_key_col);
 #    endif // SHARED_MATRIX
     }
+
+    // Disable all RGB columns before turning on PWM in case matrix read unselect high
+#    if (SN32F2XX_RGB_OUTPUT_ACTIVE_LEVEL == SN32F2XX_PWM_OUTPUT_ACTIVE_HIGH && defined(MATRIX_UNSELECT_DRIVE_HIGH))
+    for (uint8_t x = 0; x < SN32F2XX_RGB_MATRIX_COLS; x++) {
+        gpio_write_pin_low(led_col_pins[x]);
+    }
+#    endif // SN32F2XX_RGB_OUTPUT_ACTIVE_LEVEL == SN32F2XX_PWM_OUTPUT_ACTIVE_HIGH && defined(MATRIX_UNSELECT_DRIVE_HIGH)
 
     bool enable_pwm_output = false;
     for (uint8_t current_key_row = 0; current_key_row < MATRIX_ROWS; current_key_row++) {

--- a/drivers/led/sn32f2xx.c
+++ b/drivers/led/sn32f2xx.c
@@ -440,7 +440,7 @@ static void shared_matrix_rgb_disable_output(void) {
         gpio_set_pin_input(led_col_pins[x]);
 #    endif // DIODE_DIRECTION != SN32F2XX_PWM_DIRECTION
         // Unselect all columns before scanning the key matrix
-#    if (SN32F2XX_RGB_OUTPUT_ACTIVE_LEVEL == SN32F2XX_RGB_OUTPUT_ACTIVE_LOW  || defined(MATRIX_UNSELECT_DRIVE_HIGH))
+#    if (SN32F2XX_RGB_OUTPUT_ACTIVE_LEVEL == SN32F2XX_RGB_OUTPUT_ACTIVE_LOW || defined(MATRIX_UNSELECT_DRIVE_HIGH))
         gpio_write_pin_high(led_col_pins[x]);
 #    elif (SN32F2XX_RGB_OUTPUT_ACTIVE_LEVEL == SN32F2XX_RGB_OUTPUT_ACTIVE_HIGH)
         gpio_write_pin_low(led_col_pins[x]);
@@ -480,11 +480,11 @@ static void update_pwm_channels(PWMDriver *pwmp) {
     }
 
     // Disable all RGB columns before turning on PWM in case matrix read unselect high
-#    if (SN32F2XX_RGB_OUTPUT_ACTIVE_LEVEL == SN32F2XX_PWM_OUTPUT_ACTIVE_HIGH && defined(MATRIX_UNSELECT_DRIVE_HIGH))
+#    if (SN32F2XX_RGB_OUTPUT_ACTIVE_LEVEL == SN32F2XX_RGB_OUTPUT_ACTIVE_HIGH && defined(MATRIX_UNSELECT_DRIVE_HIGH))
     for (uint8_t x = 0; x < SN32F2XX_RGB_MATRIX_COLS; x++) {
         gpio_write_pin_low(led_col_pins[x]);
     }
-#    endif // SN32F2XX_RGB_OUTPUT_ACTIVE_LEVEL == SN32F2XX_PWM_OUTPUT_ACTIVE_HIGH && defined(MATRIX_UNSELECT_DRIVE_HIGH)
+#    endif // SN32F2XX_RGB_OUTPUT_ACTIVE_LEVEL == SN32F2XX_RGB_OUTPUT_ACTIVE_HIGH && defined(MATRIX_UNSELECT_DRIVE_HIGH)
 
     bool enable_pwm_output = false;
     for (uint8_t current_key_row = 0; current_key_row < MATRIX_ROWS; current_key_row++) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
I've tried to update qmk firmware on my FL980 keyboard, and the latest sn32_develop is now broken since I added this keyboard a couple of years ago.
RGB works fine, but the keys do not.
I was able to pinpoint [this commit ](https://github.com/SonixQMK/qmk_firmware/commit/cd6d6aa7122a1f69a9ce790758febec99eac8ca9).
This keyboard has odd schematics and works like this:
- Disable PWM
- Drive Cols High
- Scan matrix
- Drive Cols Low
- Enable PWM
- Enable RGB by driving Cols High as RGB_OUTPUT_ACTIVE_HIGH

<!--- Describe your changes in detail here. -->

![matrix](https://github.com/user-attachments/assets/d8e82f0c-508e-4bf1-a33f-bb7a80630f70)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
