### PR TITLE
New Lighting Effect: Solid Reactive Inverted

### DIFF
--- a/quantum/rgb_matrix/animations/rgb_matrix_effects.inc
+++ b/quantum/rgb_matrix/animations/rgb_matrix_effects.inc
@@ -37,6 +37,7 @@
 #include "solid_reactive_wide.h"
 #include "solid_reactive_cross.h"
 #include "solid_reactive_nexus.h"
+#include "solid_reactive_basic.h"
 #include "splash_anim.h"
 #include "solid_splash_anim.h"
 #include "starlight_smooth_anim.h"

--- a/quantum/rgb_matrix/animations/solid_reactive_basic.h
+++ b/quantum/rgb_matrix/animations/solid_reactive_basic.h
@@ -1,0 +1,15 @@
+#ifdef RGB_MATRIX_KEYREACTIVE_ENABLED
+#    ifdef ENABLE_RGB_MATRIX_SOLID_REACTIVE_BASIC
+RGB_MATRIX_EFFECT(SOLID_REACTIVE_BASIC)
+#        ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+
+static HSV SOLID_REACTIVE_BASIC_math(HSV hsv, uint16_t offset) {
+    hsv.v = scale8(0 + offset, hsv.v);
+    return hsv;
+}
+
+bool SOLID_REACTIVE_BASIC(effect_params_t* params) { return effect_runner_reactive(params, &SOLID_REACTIVE_BASIC_math); }
+
+#        endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+#    endif      // ENABLE_RGB_MATRIX_SOLID_REACTIVE_BASIC
+#endif          // RGB_MATRIX_KEYREACTIVE_ENABLED


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

- I quite liked the solid reactive inverted heatmap effect (Solid Color, press key to turn light off and light back up) that the stock firmware on my Keychron C2 had, so I have replicated this style for QMK that I recently installed on my Keychron K2.
- There is already a similar lighting effect, Solid Reactive Simple Anim (SRSA), but that is backwards from this. SRSA has the lights off, and pressing a key will light it up before dimming back off. This has the lights on, and pressing a key will turn it off before lighting it back up.
- The code is identical to SRSA, except this is `scale8(0 + offset, hsv.v);`, instead of `scale8(255 - offset, hsv.v);`. So I believe the same license applies to this as it does to that.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
