### PR TITLE
[Keychron C1 RGB] Fix DIP switch, disable NKRO, and update debounce

### DIFF
--- a/keyboards/keychron/c1/rgb/config.h
+++ b/keyboards/keychron/c1/rgb/config.h
@@ -1,23 +1,26 @@
-/*
-Copyright 2024 NetUserGet
+/* Copyright 2025 @ Keychron (https://www.keychron.com)
+ * Copyright 2025 vjdato21 <vjdato21@outlook.com>
+ * Copyright 2024 NetUserGet
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
 #define SN32F2XX_RGB_MATRIX_ROW_PINS  { C0, C1, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, B13, D3, B15, B14 } /* This *is* supposed to be in info.json */
 
 #define LED_MAC_PIN  B11 // Labeled Mac on KB since no Scroll Lock
 #define LED_WIN_PIN  B12 // Labeled Windows on KB since no Numpad
+#define LED_OS_PIN_ON_STATE 1
 
 // START LAYER DEFINITIONS
 #define _WIN_BASE 0

--- a/keyboards/keychron/c1/rgb/keyboard.json
+++ b/keyboards/keychron/c1/rgb/keyboard.json
@@ -1,25 +1,29 @@
 {
     "manufacturer": "Keychron",
     "keyboard_name": "Keychron C1",
-    "maintainer": "NetUserGet",
+    "maintainer": "SonixQMK",
     "development_board": "sn32f240b_shared_matrix",
     "diode_direction": "COL2ROW",
+    "build": {
+        "debounce_type": "asym_eager_defer_pk"
+    },
     "features": {
         "bootmagic": true,
         "command": false,
         "console": false,
         "extrakey": true,
         "mousekey": true,
-        "nkro": true,
         "rgb_matrix": true,
+        "nkro": false,
         "dip_switch": true
     },
-    "bootloader_instructions": "Hold FN + ESC",
+    "bootloader_instructions": "To enter bootloader: Press FN+ESC (powered), or short boot pads and plug in.",
+    "dip_switch": {
+        "enabled": true,
+        "pins": ["D4"]
+    },
     "indicators": {
         "caps_lock": "B10"
-    },
-    "dip_switch": {
-        "pins": ["D4"]
     },
     "matrix_pins": {
         "cols": ["A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15", "B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8"],
@@ -248,6 +252,7 @@
             {"matrix":[5, 15], "flags":4, "x":210, "y":64},
             {"matrix":[5, 16], "flags":4, "x":224, "y":64}
         ],
-        "sleep": true
+        "sleep": true,
+        "timeout": 300000
     }
 }

--- a/keyboards/keychron/c1/rgb/readme.md
+++ b/keyboards/keychron/c1/rgb/readme.md
@@ -85,7 +85,7 @@ In an occassion that the keyboard does not send keystrokes to your PC, press `FN
 ## Bootloader
 To enter the bootloader, you can use any of the following methods:
 - Press `FN + ESC` if the keyboard is already powered on.
-- Short the boot pads below the space bar, then plug in your keyboard."
+- Short the boot pads below the space bar, then plug in your keyboard.
 * * *
 For more information and more detailed flashing instructions, please visit [SonixQMK Docs](https://sonixqmk.github.io/qmk_docs/newbs_getting_started)
 

--- a/keyboards/keychron/c1/rgb/readme.md
+++ b/keyboards/keychron/c1/rgb/readme.md
@@ -4,7 +4,7 @@
 
 A customizable TKL keyboard.
 
-* Keyboard Maintainer(s): [SonixQMK](https://github.com/SonixQMK), [IsaacDynamo](https://github.com/IsaacDynamo), [noldevin](https://github.com/noldevin), [vjdato21](https://github.com/vjdato21) [NetUserGet](https://github.com/NetUserGet)
+* Keyboard Maintainer(s): [SonixQMK](https://github.com/SonixQMK), [IsaacDynamo](https://github.com/IsaacDynamo), [noldevin](https://github.com/noldevin), [vjdato21](https://github.com/vjdato21), [NetUserGet](https://github.com/NetUserGet)
 * Hardware Supported: Keychron C1 RGB Hot-swappable
 * Hardware Availability: [Keychron](https://www.keychron.com/products/keychron-c1-wired-mechanical-keyboard?variant=32321246986329)
 

--- a/keyboards/keychron/c1/rgb/readme.md
+++ b/keyboards/keychron/c1/rgb/readme.md
@@ -12,19 +12,14 @@ Make example for this keyboard (after setting up your build environment):
 
     make keychron/c1/rgb:default
 Flashing example for this keyboard:
-1. If your keyboard currently has stock firmware installed, put your keyboard first into bootloader by shorting the boot pins found under the spacebar before plugging in your keyboard to the PC. Otherwise, press `Fn + Esc` to put your keyboard into bootloader.
-2. Download and run [Sonix Flasher](https://github.com/SonixQMK/sonix-flasher/releases).
-3. In Sonix Flasher, select `SN32F24X` under 'Device'. And select `0x00` as the qmk offset.
-4. Lastly, click 'Flash QMK...' and find the compiled firmware.
+1. Download and run [Sonix Flasher](https://github.com/SonixQMK/sonix-flasher/releases/latest).
+2. Click `Reboot to Bootloader [HFD]`
+3. Select `SN32F24X` under 'Device'. And select `0x00` as the qmk offset.
+4. Click `Flash QMK...` and open the compiled firmware.
 
 * * *
-# Firmware Details
-### Firmware Version:
-* Default - 0.7.101
-* VIA - Supported
-* * *
-# Keymapping
-### Windows Mode
+## Keymapping
+#### Windows Mode
 <details>
 
 Without Fn | With Fn
@@ -54,7 +49,7 @@ Page Down | Decrease RGB Hue
 
 </details>
 
-### Mac Mode
+#### Mac Mode
 <details>
 
 Without Fn | With Fn
@@ -85,11 +80,13 @@ Page Down | Decrease RGB Hue
 
 </details>
 
-In an occassion that the keyboard does not send keystrokes to your PC, press `Fn + B`. This will restart your keyboard and should resolve the problem.
+In an occassion that the keyboard does not send keystrokes to your PC, press `FN + B`. This will restart your keyboard and should resolve the problem.
 * * *
-
-In an occassion that the keyboard does not send keystrokes to your PC, press `Fn + B`. This will restart your keyboard and should resolve the problem.
-
-For more information and more detailed flashing instructions, please visit https://github.com/CanUnesi/QMK-on-K6#readme
+## Bootloader
+To enter the bootloader, you can use any of the following methods:
+- Press `FN + ESC` if the keyboard is already powered on.
+- Short the boot pads below the space bar, then plug in your keyboard."
+* * *
+For more information and more detailed flashing instructions, please visit [SonixQMK Docs](https://sonixqmk.github.io/qmk_docs/newbs_getting_started)
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/keyboards/keychron/c1/rgb/rgb.c
+++ b/keyboards/keychron/c1/rgb/rgb.c
@@ -1,4 +1,5 @@
-/* Copyright 2024 NetUserGet
+/* Copyright 2025 @ Keychron (https://www.keychron.com)
+ * Copyright 2025 vjdato21 <vjdato21@outlook.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,63 +17,41 @@
 
 #include "quantum.h"
 
-bool mode_leds_show = true;
-
-
 #ifdef DIP_SWITCH_ENABLE
-    static void mode_leds_update(void){
-        if (mode_leds_show && layer_state_is(_WIN_BASE)) {
-            gpio_write_pin_high(LED_WIN_PIN);
-        } else if (mode_leds_show && layer_state_is(_MAC_BASE)) {
-            gpio_write_pin_high(LED_MAC_PIN);
-        }
+bool dip_switch_update_kb(uint8_t index, bool active) {
+    if (!dip_switch_update_user(index, active)) {
+        return false;
     }
-    bool dip_switch_update_kb(uint8_t index, bool active) {
-        if (!dip_switch_update_user(index, active)) {
-            return false;
-        }
-        if (index == 0) {
-            if (active) {
-                default_layer_state_set_kb(1 << _MAC_BASE); /* set layer 2 to be on */
-            }
-        }
-        mode_leds_update();
-        return true;
+    if (index == 0) {
+        default_layer_set(1UL << (active ? 2 : 0));
     }
-#endif // DIP_SWITCH_ENABLE
-
-
-void keyboard_pre_init_kb(void) {
-    // Setup Win & Mac LED Pins as output
-    gpio_set_pin_output(LED_WIN_PIN);
-    gpio_set_pin_output(LED_MAC_PIN);
+    return true;
 }
+#endif
 
 void keyboard_post_init_kb(void) {
-    // Setup Default Keymap.
-    // If you chose to not have the dipswich enabled change this _WIN_BASE to be your default keymap.
-    // Eg: _MAC_BASE
-    default_layer_state_set_kb(1 << _WIN_BASE); /* set layer 0 to be on */
+    gpio_set_pin_output_push_pull(LED_MAC_PIN);
+    gpio_set_pin_output_push_pull(LED_WIN_PIN);
+    gpio_write_pin(LED_MAC_PIN, !LED_OS_PIN_ON_STATE);
+    gpio_write_pin(LED_WIN_PIN, !LED_OS_PIN_ON_STATE);
+
+    keyboard_post_init_user();
 }
 
-
-#ifdef RGB_MATRIX_SLEEP
-    void suspend_power_down_kb(void) {
-        // Turn leds off
-        mode_leds_show = false;
-        mode_leds_update();
-      
-        #ifdef RGB_MATRIX
-        rgb_matrix_set_suspend_state(true);
-        #endif
-    
+void housekeeping_task_kb(void) {
+    if (default_layer_state == (1U << 2)) {
+        gpio_write_pin(LED_MAC_PIN, LED_OS_PIN_ON_STATE);
+        gpio_write_pin(LED_WIN_PIN, !LED_OS_PIN_ON_STATE);
     }
-
-    void suspend_wakeup_init_kb(void) {
-        mode_leds_show = true;
-        mode_leds_update();
-        #ifdef RGB_MATRIX
-        rgb_matrix_set_suspend_state(false);
-        #endif
+    if (default_layer_state == (1U << 0)) {
+        gpio_write_pin(LED_MAC_PIN, !LED_OS_PIN_ON_STATE);
+        gpio_write_pin(LED_WIN_PIN, LED_OS_PIN_ON_STATE);
     }
-#endif // RGB_MATRIX_SLEEP
+}
+
+void suspend_power_down_kb(void) {
+    gpio_write_pin(LED_WIN_PIN, !LED_OS_PIN_ON_STATE);
+    gpio_write_pin(LED_MAC_PIN, !LED_OS_PIN_ON_STATE);
+
+    suspend_power_down_user();
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
- DIP switch logic mirrored from Keychron's.
- Disable NKRO. At least with VIA, NKRO becomes a problematic feature.
- Change debounce type to `asym_eager_defer_pk` for better responsiveness.
- Update flash instructions, added bootloader instructions, etc. in `readme.md`
- Added sleep support for RGB matrix, and disable RGB matrix after 5 mins. of inactivity.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* Keyboard locks up when compiled with VIA keymap.
* DIP switch doesn't switch layer nor update the LEDs.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
