### PR TITLE
[DM01] fix build, indicator_set_color doesnt accept color macro alias

### DIFF
--- a/keyboards/designedbygg/darkmage/keymaps/default/keymap.c
+++ b/keyboards/designedbygg/darkmage/keymaps/default/keymap.c
@@ -56,7 +56,7 @@ const uint16_t PROGMEM encoder_map[][1][2] = {
 #if defined(CAPS_LOCK_LED_INDEX)
 bool rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
     if (host_keyboard_led_state().caps_lock) {
-        RGB_MATRIX_INDICATOR_SET_COLOR(CAPS_LOCK_LED_INDEX, RGB_WHITE);
+        rgb_matrix_set_color(CAPS_LOCK_LED_INDEX, RGB_WHITE);
     }
     return false;
 }

--- a/keyboards/designedbygg/darkmage/keymaps/default/keymap.c
+++ b/keyboards/designedbygg/darkmage/keymaps/default/keymap.c
@@ -53,7 +53,7 @@ const uint16_t PROGMEM encoder_map[][1][2] = {
 };
 #endif
 
-#if defined(CAPS_LOCK_LED_INDEX)
+#if defined(RGB_MATRIX_ENABLE) && defined(CAPS_LOCK_LED_INDEX)
 bool rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
     if (host_keyboard_led_state().caps_lock) {
         rgb_matrix_set_color(CAPS_LOCK_LED_INDEX, RGB_WHITE);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

From recent Dark Mage indicator PR, method use was incorrect
```
/qmk_userspace/keyboards/designedbygg/darkmage/keymaps/via/keymap.c: In function 'rgb_matrix_indicators_advanced_user':
/qmk_userspace/keyboards/designedbygg/darkmage/keymaps/via/keymap.c:59:70: error: macro "RGB_MATRIX_INDICATOR_SET_COLOR" requires 4 arguments, but only 2 given
         RGB_MATRIX_INDICATOR_SET_COLOR(CAPS_LOCK_LED_INDEX, RGB_WHITE);
                                                                      ^
/qmk_userspace/keyboards/designedbygg/darkmage/keymaps/via/keymap.c:59:9: error: 'RGB_MATRIX_INDICATOR_SET_COLOR' undeclared (first use in this function); did you mean 'RGB_MATRIX_SOLID_COLOR'?
         RGB_MATRIX_INDICATOR_SET_COLOR(CAPS_LOCK_LED_INDEX, RGB_WHITE);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         RGB_MATRIX_SOLID_COLOR
/qmk_userspace/keyboards/designedbygg/darkmage/keymaps/via/keymap.c:59:9: note: each undeclared identifier is reported only once for each function it appears in
 [ERRORS]
 | 
 | 
 | 
make[1]: *** [builddefs/common_rules.mk:362: .build/obj_designedbygg_darkmage_via/quantum/keymap_introspection.o] Error 1
```
Make finished with errors

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
using correct function that can use color alias macro as a parameter

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
