### PR TITLE
Added legacy ChibiOS USB endpoints before async for SN32F260

### DIFF
--- a/tmk_core/protocol/chibios/chibios.mk
+++ b/tmk_core/protocol/chibios/chibios.mk
@@ -2,12 +2,19 @@ PROTOCOL_DIR = protocol
 CHIBIOS_DIR = $(PROTOCOL_DIR)/chibios
 
 
+ifneq ($(filter $(MCU_SERIES),SN32F260),)
+SRC += $(CHIBIOS_DIR)/usb_legacy/usb_main.c
+SRC += $(CHIBIOS_DIR)/usb_legacy/chibios.c
+SRC += usb_descriptor.c
+SRC += $(CHIBIOS_DIR)/usb_legacy/usb_driver.c
+else
 SRC += $(CHIBIOS_DIR)/usb_main.c
 SRC += $(CHIBIOS_DIR)/chibios.c
 SRC += usb_descriptor.c
 SRC += $(CHIBIOS_DIR)/usb_driver.c
 SRC += $(CHIBIOS_DIR)/usb_endpoints.c
 SRC += $(CHIBIOS_DIR)/usb_report_handling.c
+endif
 SRC += $(CHIBIOS_DIR)/usb_util.c
 SRC += $(LIBSRC)
 

--- a/tmk_core/protocol/chibios/chibios.mk
+++ b/tmk_core/protocol/chibios/chibios.mk
@@ -3,18 +3,28 @@ CHIBIOS_DIR = $(PROTOCOL_DIR)/chibios
 
 
 ifneq ($(filter $(MCU_SERIES),SN32F260),)
-SRC += $(CHIBIOS_DIR)/usb_legacy/usb_main.c
-SRC += $(CHIBIOS_DIR)/usb_legacy/chibios.c
-SRC += usb_descriptor.c
-SRC += $(CHIBIOS_DIR)/usb_legacy/usb_driver.c
+    CHIBIOS_USB_PROTOCOL ?= legacy
+    ifeq ($(strip $(CHIBIOS_USB_PROTOCOL)), legacy)
+        SRC += $(CHIBIOS_DIR)/usb_legacy/usb_main.c
+        SRC += $(CHIBIOS_DIR)/usb_legacy/chibios.c
+        SRC += usb_descriptor.c
+        SRC += $(CHIBIOS_DIR)/usb_legacy/usb_driver.c
+    else ifeq ($(strip $(CHIBIOS_USB_PROTOCOL)), async)
+        USB_ASYNC_ENABLE := yes
+    endif
 else
-SRC += $(CHIBIOS_DIR)/usb_main.c
-SRC += $(CHIBIOS_DIR)/chibios.c
-SRC += usb_descriptor.c
-SRC += $(CHIBIOS_DIR)/usb_driver.c
-SRC += $(CHIBIOS_DIR)/usb_endpoints.c
-SRC += $(CHIBIOS_DIR)/usb_report_handling.c
+    USB_ASYNC_ENABLE := yes
 endif
+
+ifeq ($(strip $(USB_ASYNC_ENABLE)), yes)
+    SRC += $(CHIBIOS_DIR)/usb_main.c
+    SRC += $(CHIBIOS_DIR)/chibios.c
+    SRC += usb_descriptor.c
+    SRC += $(CHIBIOS_DIR)/usb_driver.c
+    SRC += $(CHIBIOS_DIR)/usb_endpoints.c
+    SRC += $(CHIBIOS_DIR)/usb_report_handling.c
+endif
+
 SRC += $(CHIBIOS_DIR)/usb_util.c
 SRC += $(LIBSRC)
 

--- a/tmk_core/protocol/chibios/usb_legacy/chibios.c
+++ b/tmk_core/protocol/chibios/usb_legacy/chibios.c
@@ -1,0 +1,209 @@
+/*
+ * (c) 2015 flabberast <s3+flabbergast@sdfeu.org>
+ *
+ * Based on the following work:
+ *  - Guillaume Duc's raw hid example (MIT License)
+ *    https://github.com/guiduc/usb-hid-chibios-example
+ *  - PJRC Teensy examples (MIT License)
+ *    https://www.pjrc.com/teensy/usb_keyboard.html
+ *  - hasu's TMK keyboard code (GPL v2 and some code Modified BSD)
+ *    https://github.com/tmk/tmk_keyboard/
+ *  - ChibiOS demo code (Apache 2.0 License)
+ *    http://www.chibios.org
+ *
+ * Since some GPL'd code is used, this work is licensed under
+ * GPL v2 or later.
+ */
+
+#include <ch.h>
+#include <hal.h>
+
+#include "usb_main.h"
+
+/* TMK includes */
+#include "report.h"
+#include "host.h"
+#include "host_driver.h"
+#include "keyboard.h"
+#include "action.h"
+#include "action_util.h"
+#include "usb_device_state.h"
+#include "mousekey.h"
+#include "led.h"
+#include "sendchar.h"
+#include "debug.h"
+#include "print.h"
+
+#ifndef EARLY_INIT_PERFORM_BOOTLOADER_JUMP
+// Change this to be TRUE once we've migrated keyboards to the new init system
+// Remember to change docs/platformdev_chibios_earlyinit.md as well.
+#    define EARLY_INIT_PERFORM_BOOTLOADER_JUMP FALSE
+#endif
+
+#ifdef MIDI_ENABLE
+#    include "qmk_midi.h"
+#endif
+#include "suspend.h"
+#include "wait.h"
+
+#define USB_GETSTATUS_REMOTE_WAKEUP_ENABLED (2U)
+
+#ifdef WAIT_FOR_USB
+// TODO: Remove backwards compatibility with old define
+#    define USB_WAIT_FOR_ENUMERATION
+#endif
+
+/* -------------------------
+ *   TMK host driver defs
+ * -------------------------
+ */
+
+/* declarations */
+void send_keyboard(report_keyboard_t *report);
+void send_nkro(report_nkro_t *report);
+void send_mouse(report_mouse_t *report);
+void send_extra(report_extra_t *report);
+void send_raw_hid(uint8_t *data, uint8_t length);
+
+/* host struct */
+host_driver_t chibios_driver = {
+    .keyboard_leds = usb_device_state_get_leds,
+    .send_keyboard = send_keyboard,
+    .send_nkro     = send_nkro,
+    .send_mouse    = send_mouse,
+    .send_extra    = send_extra,
+#ifdef RAW_ENABLE
+    .send_raw_hid = send_raw_hid,
+#endif
+};
+
+#ifdef VIRTSER_ENABLE
+void virtser_task(void);
+#endif
+
+/* TESTING
+ * Amber LED blinker thread, times are in milliseconds.
+ */
+/* set this variable to non-zero anywhere to blink once */
+// static THD_WORKING_AREA(waThread1, 128);
+// static THD_FUNCTION(Thread1, arg) {
+
+//   (void)arg;
+//   chRegSetThreadName("blinker");
+//   while (true) {
+//     systime_t time;
+
+//     time = USB_DRIVER.state == USB_ACTIVE ? 250 : 500;
+//     palClearLine(LINE_CAPS_LOCK);
+//     chSysPolledDelayX(MS2RTC(STM32_HCLK, time));
+//     palSetLine(LINE_CAPS_LOCK);
+//     chSysPolledDelayX(MS2RTC(STM32_HCLK, time));
+//   }
+// }
+
+/* Early initialisation
+ */
+__attribute__((weak)) void early_hardware_init_pre(void) {
+#if EARLY_INIT_PERFORM_BOOTLOADER_JUMP
+    void enter_bootloader_mode_if_requested(void);
+    enter_bootloader_mode_if_requested();
+#endif // EARLY_INIT_PERFORM_BOOTLOADER_JUMP
+}
+
+__attribute__((weak)) void early_hardware_init_post(void) {}
+
+__attribute__((weak)) void board_init(void) {}
+
+// This overrides what's normally in ChibiOS board definitions
+void __early_init(void) {
+    early_hardware_init_pre();
+
+    // This is the renamed equivalent of __early_init in the board.c file
+    void __chibios_override___early_init(void);
+    __chibios_override___early_init();
+
+    early_hardware_init_post();
+}
+
+// This overrides what's normally in ChibiOS board definitions
+void boardInit(void) {
+    // This is the renamed equivalent of boardInit in the board.c file
+    void __chibios_override_boardInit(void);
+    __chibios_override_boardInit();
+
+    board_init();
+}
+
+void protocol_setup(void) {
+    usb_device_state_init();
+
+    // TESTING
+    // chThdCreateStatic(waThread1, sizeof(waThread1), NORMALPRIO, Thread1, NULL);
+}
+
+void protocol_pre_init(void) {
+    /* Init USB */
+    usb_event_queue_init();
+    init_usb_driver(&USB_DRIVER);
+
+#ifdef MIDI_ENABLE
+    setup_midi();
+#endif
+
+    /* Wait until USB is active */
+#ifdef USB_WAIT_FOR_ENUMERATION
+    while (USB_DRIVER.state != USB_ACTIVE) {
+        wait_ms(50);
+    }
+#endif
+
+    /* Do need to wait here!
+     * Otherwise the next print might start a transfer on console EP
+     * before the USB is completely ready, which sometimes causes
+     * HardFaults.
+     */
+    wait_ms(50);
+
+    print("USB configured.\n");
+}
+
+void protocol_post_init(void) {
+    host_set_driver(&chibios_driver);
+}
+
+void protocol_pre_task(void) {
+    usb_event_queue_task();
+
+#if !defined(NO_USB_STARTUP_CHECK)
+    if (USB_DRIVER.state == USB_SUSPENDED) {
+        dprintln("suspending keyboard");
+        while (USB_DRIVER.state == USB_SUSPENDED) {
+            /* Do this in the suspended state */
+            suspend_power_down(); // on AVR this deep sleeps for 15ms
+            /* Remote wakeup */
+            if (suspend_wakeup_condition() && (USB_DRIVER.status & USB_GETSTATUS_REMOTE_WAKEUP_ENABLED)) {
+                usbWakeupHost(&USB_DRIVER);
+#    if USB_SUSPEND_WAKEUP_DELAY > 0
+                // Some hubs, kvm switches, and monitors do
+                // weird things, with USB device state bouncing
+                // around wildly on wakeup, yielding race
+                // conditions that can corrupt the keyboard state.
+                //
+                // Pause for a while to let things settle...
+                wait_ms(USB_SUSPEND_WAKEUP_DELAY);
+                // ...and then update the wakeup matrix again as the waking key
+                // might have been released during the delay
+                update_matrix_state_after_wakeup();
+#    endif
+            }
+        }
+        /* Woken up */
+    }
+#endif
+}
+
+void protocol_post_task(void) {
+#ifdef VIRTSER_ENABLE
+    virtser_task();
+#endif
+}

--- a/tmk_core/protocol/chibios/usb_legacy/usb_driver.c
+++ b/tmk_core/protocol/chibios/usb_legacy/usb_driver.c
@@ -1,0 +1,465 @@
+/*
+    ChibiOS - Copyright (C) 2006..2016 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    hal_serial_usb.c
+ * @brief   Serial over USB Driver code.
+ *
+ * @addtogroup SERIAL_USB
+ * @{
+ */
+
+#include <hal.h>
+#include "usb_driver.h"
+#include <string.h>
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/*
+ * Current Line Coding.
+ */
+static cdc_linecoding_t linecoding = {{0x00, 0x96, 0x00, 0x00}, /* 38400.                           */
+                                      LC_STOP_1,
+                                      LC_PARITY_NONE,
+                                      8};
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+static bool qmkusb_start_receive(QMKUSBDriver *qmkusbp) {
+    uint8_t *buf;
+
+    /* If the USB driver is not in the appropriate state then transactions
+       must not be started.*/
+    if ((usbGetDriverStateI(qmkusbp->config->usbp) != USB_ACTIVE) || (qmkusbp->state != QMKUSB_READY)) {
+        return true;
+    }
+
+    /* Checking if there is already a transaction ongoing on the endpoint.*/
+    if (usbGetReceiveStatusI(qmkusbp->config->usbp, qmkusbp->config->bulk_out)) {
+        return true;
+    }
+
+    /* Checking if there is a buffer ready for incoming data.*/
+    buf = ibqGetEmptyBufferI(&qmkusbp->ibqueue);
+    if (buf == NULL) {
+        return true;
+    }
+
+    /* Buffer found, starting a new transaction.*/
+    usbStartReceiveI(qmkusbp->config->usbp, qmkusbp->config->bulk_out, buf, qmkusbp->ibqueue.bsize - sizeof(size_t));
+
+    return false;
+}
+
+/*
+ * Interface implementation.
+ */
+
+static size_t _write(void *ip, const uint8_t *bp, size_t n) {
+    return obqWriteTimeout(&((QMKUSBDriver *)ip)->obqueue, bp, n, TIME_INFINITE);
+}
+
+static size_t _read(void *ip, uint8_t *bp, size_t n) {
+    return ibqReadTimeout(&((QMKUSBDriver *)ip)->ibqueue, bp, n, TIME_INFINITE);
+}
+
+static msg_t _put(void *ip, uint8_t b) {
+    return obqPutTimeout(&((QMKUSBDriver *)ip)->obqueue, b, TIME_INFINITE);
+}
+
+static msg_t _get(void *ip) {
+    return ibqGetTimeout(&((QMKUSBDriver *)ip)->ibqueue, TIME_INFINITE);
+}
+
+static msg_t _putt(void *ip, uint8_t b, sysinterval_t timeout) {
+    return obqPutTimeout(&((QMKUSBDriver *)ip)->obqueue, b, timeout);
+}
+
+static msg_t _gett(void *ip, sysinterval_t timeout) {
+    return ibqGetTimeout(&((QMKUSBDriver *)ip)->ibqueue, timeout);
+}
+
+static size_t _writet(void *ip, const uint8_t *bp, size_t n, sysinterval_t timeout) {
+    return obqWriteTimeout(&((QMKUSBDriver *)ip)->obqueue, bp, n, timeout);
+}
+
+static size_t _readt(void *ip, uint8_t *bp, size_t n, sysinterval_t timeout) {
+    return ibqReadTimeout(&((QMKUSBDriver *)ip)->ibqueue, bp, n, timeout);
+}
+
+static const struct QMKUSBDriverVMT vmt = {0, _write, _read, _put, _get, _putt, _gett, _writet, _readt};
+
+/**
+ * @brief   Notification of empty buffer released into the input buffers queue.
+ *
+ * @param[in] bqp       the buffers queue pointer.
+ */
+static void ibnotify(io_buffers_queue_t *bqp) {
+    QMKUSBDriver *qmkusbp = bqGetLinkX(bqp);
+    (void)qmkusb_start_receive(qmkusbp);
+}
+
+/**
+ * @brief   Notification of filled buffer inserted into the output buffers queue.
+ *
+ * @param[in] bqp       the buffers queue pointer.
+ */
+static void obnotify(io_buffers_queue_t *bqp) {
+    size_t        n;
+    QMKUSBDriver *qmkusbp = bqGetLinkX(bqp);
+
+    /* If the USB driver is not in the appropriate state then transactions
+       must not be started.*/
+    if ((usbGetDriverStateI(qmkusbp->config->usbp) != USB_ACTIVE) || (qmkusbp->state != QMKUSB_READY)) {
+        return;
+    }
+
+    /* Checking if there is already a transaction ongoing on the endpoint.*/
+    if (!usbGetTransmitStatusI(qmkusbp->config->usbp, qmkusbp->config->bulk_in)) {
+        /* Trying to get a full buffer.*/
+        uint8_t *buf = obqGetFullBufferI(&qmkusbp->obqueue, &n);
+        if (buf != NULL) {
+            /* Buffer found, starting a new transaction.*/
+            usbStartTransmitI(qmkusbp->config->usbp, qmkusbp->config->bulk_in, buf, n);
+        }
+    }
+}
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Serial Driver initialization.
+ * @note    This function is implicitly invoked by @p halInit(), there is
+ *          no need to explicitly initialize the driver.
+ *
+ * @init
+ */
+void qmkusbInit(void) {}
+
+/**
+ * @brief   Initializes a generic full duplex driver object.
+ * @details The HW dependent part of the initialization has to be performed
+ *          outside, usually in the hardware initialization code.
+ *
+ * @param[out] qmkusbp     pointer to a @p QMKUSBDriver structure
+ *
+ * @init
+ */
+void qmkusbObjectInit(QMKUSBDriver *qmkusbp, const QMKUSBConfig *config) {
+    qmkusbp->vmt = &vmt;
+    osalEventObjectInit(&qmkusbp->event);
+    qmkusbp->state = QMKUSB_STOP;
+    // Note that the config uses the USB direction naming
+    ibqObjectInit(&qmkusbp->ibqueue, true, config->ob, config->out_size, config->out_buffers, ibnotify, qmkusbp);
+    obqObjectInit(&qmkusbp->obqueue, true, config->ib, config->in_size, config->in_buffers, obnotify, qmkusbp);
+}
+
+/**
+ * @brief   Configures and starts the driver.
+ *
+ * @param[in] qmkusbp      pointer to a @p QMKUSBDriver object
+ * @param[in] config    the serial over USB driver configuration
+ *
+ * @api
+ */
+void qmkusbStart(QMKUSBDriver *qmkusbp, const QMKUSBConfig *config) {
+    USBDriver *usbp = config->usbp;
+
+    osalDbgCheck(qmkusbp != NULL);
+
+    osalSysLock();
+    osalDbgAssert((qmkusbp->state == QMKUSB_STOP) || (qmkusbp->state == QMKUSB_READY), "invalid state");
+    usbp->in_params[config->bulk_in - 1U]   = qmkusbp;
+    usbp->out_params[config->bulk_out - 1U] = qmkusbp;
+    if (config->int_in > 0U) {
+        usbp->in_params[config->int_in - 1U] = qmkusbp;
+    }
+    qmkusbp->config = config;
+    qmkusbp->state  = QMKUSB_READY;
+    osalSysUnlock();
+}
+
+/**
+ * @brief   Stops the driver.
+ * @details Any thread waiting on the driver's queues will be awakened with
+ *          the message @p MSG_RESET.
+ *
+ * @param[in] qmkusbp      pointer to a @p QMKUSBDriver object
+ *
+ * @api
+ */
+void qmkusbStop(QMKUSBDriver *qmkusbp) {
+    USBDriver *usbp = qmkusbp->config->usbp;
+
+    osalDbgCheck(qmkusbp != NULL);
+
+    osalSysLock();
+
+    osalDbgAssert((qmkusbp->state == QMKUSB_STOP) || (qmkusbp->state == QMKUSB_READY), "invalid state");
+
+    /* Driver in stopped state.*/
+    usbp->in_params[qmkusbp->config->bulk_in - 1U]   = NULL;
+    usbp->out_params[qmkusbp->config->bulk_out - 1U] = NULL;
+    if (qmkusbp->config->int_in > 0U) {
+        usbp->in_params[qmkusbp->config->int_in - 1U] = NULL;
+    }
+    qmkusbp->config = NULL;
+    qmkusbp->state  = QMKUSB_STOP;
+
+    /* Enforces a disconnection.*/
+    chnAddFlagsI(qmkusbp, CHN_DISCONNECTED);
+    ibqResetI(&qmkusbp->ibqueue);
+    obqResetI(&qmkusbp->obqueue);
+    osalOsRescheduleS();
+
+    osalSysUnlock();
+}
+
+/**
+ * @brief   USB device suspend handler.
+ * @details Generates a @p CHN_DISCONNECT event and puts queues in
+ *          non-blocking mode, this way the application cannot get stuck
+ *          in the middle of an I/O operations.
+ * @note    If this function is not called from an ISR then an explicit call
+ *          to @p osalOsRescheduleS() in necessary afterward.
+ *
+ * @param[in] qmkusbp      pointer to a @p QMKUSBDriver object
+ *
+ * @iclass
+ */
+void qmkusbSuspendHookI(QMKUSBDriver *qmkusbp) {
+    chnAddFlagsI(qmkusbp, CHN_DISCONNECTED);
+    bqSuspendI(&qmkusbp->ibqueue);
+    bqSuspendI(&qmkusbp->obqueue);
+}
+
+/**
+ * @brief   USB device wakeup handler.
+ * @details Generates a @p CHN_CONNECT event and resumes normal queues
+ *          operations.
+ *
+ * @note    If this function is not called from an ISR then an explicit call
+ *          to @p osalOsRescheduleS() in necessary afterward.
+ *
+ * @param[in] qmkusbp      pointer to a @p QMKUSBDriver object
+ *
+ * @iclass
+ */
+void qmkusbWakeupHookI(QMKUSBDriver *qmkusbp) {
+    chnAddFlagsI(qmkusbp, CHN_CONNECTED);
+    bqResumeX(&qmkusbp->ibqueue);
+    bqResumeX(&qmkusbp->obqueue);
+}
+
+/**
+ * @brief   USB device configured handler.
+ *
+ * @param[in] qmkusbp      pointer to a @p QMKUSBDriver object
+ *
+ * @iclass
+ */
+void qmkusbConfigureHookI(QMKUSBDriver *qmkusbp) {
+    ibqResetI(&qmkusbp->ibqueue);
+    bqResumeX(&qmkusbp->ibqueue);
+    obqResetI(&qmkusbp->obqueue);
+    bqResumeX(&qmkusbp->obqueue);
+    chnAddFlagsI(qmkusbp, CHN_CONNECTED);
+    (void)qmkusb_start_receive(qmkusbp);
+}
+
+/**
+ * @brief   Default requests hook.
+ * @details Applications wanting to use the Serial over USB driver can use
+ *          this function as requests hook in the USB configuration.
+ *          The following requests are emulated:
+ *          - CDC_GET_LINE_CODING.
+ *          - CDC_SET_LINE_CODING.
+ *          - CDC_SET_CONTROL_LINE_STATE.
+ *          .
+ *
+ * @param[in] usbp      pointer to the @p USBDriver object
+ * @return              The hook status.
+ * @retval true         Message handled internally.
+ * @retval false        Message not handled.
+ */
+bool qmkusbRequestsHook(USBDriver *usbp) {
+    if ((usbp->setup[0] & USB_RTYPE_TYPE_MASK) == USB_RTYPE_TYPE_CLASS) {
+        switch (usbp->setup[1]) {
+            case CDC_GET_LINE_CODING:
+                usbSetupTransfer(usbp, (uint8_t *)&linecoding, sizeof(linecoding), NULL);
+                return true;
+            case CDC_SET_LINE_CODING:
+                usbSetupTransfer(usbp, (uint8_t *)&linecoding, sizeof(linecoding), NULL);
+                return true;
+            case CDC_SET_CONTROL_LINE_STATE:
+                /* Nothing to do, there are no control lines.*/
+                usbSetupTransfer(usbp, NULL, 0, NULL);
+                return true;
+            default:
+                return false;
+        }
+    }
+    return false;
+}
+
+/**
+ * @brief   SOF handler.
+ * @details The SOF interrupt is used for automatic flushing of incomplete
+ *          buffers pending in the output queue.
+ *
+ * @param[in] qmkusbp      pointer to a @p QMKUSBDriver object
+ *
+ * @iclass
+ */
+void qmkusbSOFHookI(QMKUSBDriver *qmkusbp) {
+    /* If the USB driver is not in the appropriate state then transactions
+       must not be started.*/
+    if ((usbGetDriverStateI(qmkusbp->config->usbp) != USB_ACTIVE) || (qmkusbp->state != QMKUSB_READY)) {
+        return;
+    }
+
+    /* If there is already a transaction ongoing then another one cannot be
+       started.*/
+    if (usbGetTransmitStatusI(qmkusbp->config->usbp, qmkusbp->config->bulk_in)) {
+        return;
+    }
+
+    /* Checking if there only a buffer partially filled, if so then it is
+       enforced in the queue and transmitted.*/
+    if (obqTryFlushI(&qmkusbp->obqueue)) {
+        size_t   n;
+        uint8_t *buf = obqGetFullBufferI(&qmkusbp->obqueue, &n);
+
+        /* For fixed size drivers, fill the end with zeros */
+        if (qmkusbp->config->fixed_size) {
+            memset(buf + n, 0, qmkusbp->config->in_size - n);
+            n = qmkusbp->config->in_size;
+        }
+
+        osalDbgAssert(buf != NULL, "queue is empty");
+
+        usbStartTransmitI(qmkusbp->config->usbp, qmkusbp->config->bulk_in, buf, n);
+    }
+}
+
+/**
+ * @brief   Default data transmitted callback.
+ * @details The application must use this function as callback for the IN
+ *          data endpoint.
+ *
+ * @param[in] usbp      pointer to the @p USBDriver object
+ * @param[in] ep        IN endpoint number
+ */
+void qmkusbDataTransmitted(USBDriver *usbp, usbep_t ep) {
+    uint8_t *     buf;
+    size_t        n;
+    QMKUSBDriver *qmkusbp = usbp->in_params[ep - 1U];
+
+    if (qmkusbp == NULL) {
+        return;
+    }
+
+    osalSysLockFromISR();
+
+    /* Signaling that space is available in the output queue.*/
+    chnAddFlagsI(qmkusbp, CHN_OUTPUT_EMPTY);
+
+    /* Freeing the buffer just transmitted, if it was not a zero size packet.*/
+    if (usbp->epc[ep]->in_state->txsize > 0U) {
+        obqReleaseEmptyBufferI(&qmkusbp->obqueue);
+    }
+
+    /* Checking if there is a buffer ready for transmission.*/
+    buf = obqGetFullBufferI(&qmkusbp->obqueue, &n);
+
+    if (buf != NULL) {
+        /* The endpoint cannot be busy, we are in the context of the callback,
+           so it is safe to transmit without a check.*/
+        usbStartTransmitI(usbp, ep, buf, n);
+    } else if ((usbp->epc[ep]->in_state->txsize > 0U) && ((usbp->epc[ep]->in_state->txsize & ((size_t)usbp->epc[ep]->in_maxsize - 1U)) == 0U)) {
+        /* Transmit zero sized packet in case the last one has maximum allowed
+           size. Otherwise the recipient may expect more data coming soon and
+           not return buffered data to app. See section 5.8.3 Bulk Transfer
+           Packet Size Constraints of the USB Specification document.*/
+        if (!qmkusbp->config->fixed_size) {
+            usbStartTransmitI(usbp, ep, usbp->setup, 0);
+        }
+
+    } else {
+        /* Nothing to transmit.*/
+    }
+
+    osalSysUnlockFromISR();
+}
+
+/**
+ * @brief   Default data received callback.
+ * @details The application must use this function as callback for the OUT
+ *          data endpoint.
+ *
+ * @param[in] usbp      pointer to the @p USBDriver object
+ * @param[in] ep        OUT endpoint number
+ */
+void qmkusbDataReceived(USBDriver *usbp, usbep_t ep) {
+    QMKUSBDriver *qmkusbp = usbp->out_params[ep - 1U];
+    if (qmkusbp == NULL) {
+        return;
+    }
+
+    osalSysLockFromISR();
+
+    /* Signaling that data is available in the input queue.*/
+    chnAddFlagsI(qmkusbp, CHN_INPUT_AVAILABLE);
+
+    /* Posting the filled buffer in the queue.*/
+    ibqPostFullBufferI(&qmkusbp->ibqueue, usbGetReceiveTransactionSizeX(qmkusbp->config->usbp, qmkusbp->config->bulk_out));
+
+    /* The endpoint cannot be busy, we are in the context of the callback,
+       so a packet is in the buffer for sure. Trying to get a free buffer
+       for the next transaction.*/
+    (void)qmkusb_start_receive(qmkusbp);
+
+    osalSysUnlockFromISR();
+}
+
+/**
+ * @brief   Default data received callback.
+ * @details The application must use this function as callback for the IN
+ *          interrupt endpoint.
+ *
+ * @param[in] usbp      pointer to the @p USBDriver object
+ * @param[in] ep        endpoint number
+ */
+void qmkusbInterruptTransmitted(USBDriver *usbp, usbep_t ep) {
+    (void)usbp;
+    (void)ep;
+}
+
+/** @} */

--- a/tmk_core/protocol/chibios/usb_legacy/usb_driver.c
+++ b/tmk_core/protocol/chibios/usb_legacy/usb_driver.c
@@ -378,7 +378,7 @@ void qmkusbSOFHookI(QMKUSBDriver *qmkusbp) {
  * @param[in] ep        IN endpoint number
  */
 void qmkusbDataTransmitted(USBDriver *usbp, usbep_t ep) {
-    uint8_t *     buf;
+    uint8_t      *buf;
     size_t        n;
     QMKUSBDriver *qmkusbp = usbp->in_params[ep - 1U];
 

--- a/tmk_core/protocol/chibios/usb_legacy/usb_driver.h
+++ b/tmk_core/protocol/chibios/usb_legacy/usb_driver.h
@@ -1,0 +1,179 @@
+/*
+    ChibiOS - Copyright (C) 2006..2016 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    usb_driver.h
+ * @brief   Usb driver suitable for both packet and serial formats
+ *
+ * @addtogroup SERIAL_USB
+ * @{
+ */
+
+#pragma once
+
+#include <hal_usb_cdc.h>
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+#if HAL_USE_USB == FALSE
+#    error "The USB Driver requires HAL_USE_USB"
+#endif
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief Driver state machine possible states.
+ */
+typedef enum {
+    QMKUSB_UNINIT = 0, /**< Not initialized.                   */
+    QMKUSB_STOP   = 1, /**< Stopped.                           */
+    QMKUSB_READY  = 2  /**< Ready.                             */
+} qmkusbstate_t;
+
+/**
+ * @brief   Structure representing a serial over USB driver.
+ */
+typedef struct QMKUSBDriver QMKUSBDriver;
+
+/**
+ * @brief   Serial over USB Driver configuration structure.
+ * @details An instance of this structure must be passed to @p sduStart()
+ *          in order to configure and start the driver operations.
+ */
+typedef struct {
+    /**
+     * @brief   USB driver to use.
+     */
+    USBDriver *usbp;
+    /**
+     * @brief   Bulk IN endpoint used for outgoing data transfer.
+     */
+    usbep_t bulk_in;
+    /**
+     * @brief   Bulk OUT endpoint used for incoming data transfer.
+     */
+    usbep_t bulk_out;
+    /**
+     * @brief   Interrupt IN endpoint used for notifications.
+     * @note    If set to zero then the INT endpoint is assumed to be not
+     *          present, USB descriptors must be changed accordingly.
+     */
+    usbep_t int_in;
+
+    /**
+     * @brief The number of buffers in the queues
+     */
+    size_t in_buffers;
+    size_t out_buffers;
+
+    /**
+     * @brief The size of each buffer in the queue, typically the same as the endpoint size
+     */
+    size_t in_size;
+    size_t out_size;
+
+    /**
+     * @brief Always send full buffers in_size (the rest is filled with zeroes)
+     */
+    bool fixed_size;
+
+    /* Input buffer
+     * @note needs to be initialized with a memory buffer of the right size
+     */
+    uint8_t *ib;
+    /* Output buffer
+     * @note needs to be initialized with a memory buffer of the right size
+     */
+    uint8_t *ob;
+} QMKUSBConfig;
+
+/**
+ * @brief   @p SerialDriver specific data.
+ */
+#define _qmk_usb_driver_data                           \
+    _base_asynchronous_channel_data /* Driver state.*/ \
+        qmkusbstate_t state;                           \
+    /* Input buffers queue.*/                          \
+    input_buffers_queue_t ibqueue;                     \
+    /* Output queue.*/                                 \
+    output_buffers_queue_t obqueue;                    \
+    /* End of the mandatory fields.*/                  \
+    /* Current configuration data.*/                   \
+    const QMKUSBConfig *config;
+
+/**
+ * @brief   @p SerialUSBDriver specific methods.
+ */
+#define _qmk_usb_driver_methods _base_asynchronous_channel_methods
+
+/**
+ * @extends BaseAsynchronousChannelVMT
+ *
+ * @brief   @p SerialDriver virtual methods table.
+ */
+struct QMKUSBDriverVMT {
+    _qmk_usb_driver_methods
+};
+
+/**
+ * @extends BaseAsynchronousChannel
+ *
+ * @brief   Full duplex serial driver class.
+ * @details This class extends @p BaseAsynchronousChannel by adding physical
+ *          I/O queues.
+ */
+struct QMKUSBDriver {
+    /** @brief Virtual Methods Table.*/
+    const struct QMKUSBDriverVMT *vmt;
+    _qmk_usb_driver_data
+};
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+void qmkusbInit(void);
+void qmkusbObjectInit(QMKUSBDriver *qmkusbp, const QMKUSBConfig *config);
+void qmkusbStart(QMKUSBDriver *qmkusbp, const QMKUSBConfig *config);
+void qmkusbStop(QMKUSBDriver *qmkusbp);
+void qmkusbSuspendHookI(QMKUSBDriver *qmkusbp);
+void qmkusbWakeupHookI(QMKUSBDriver *qmkusbp);
+void qmkusbConfigureHookI(QMKUSBDriver *qmkusbp);
+bool qmkusbRequestsHook(USBDriver *usbp);
+void qmkusbSOFHookI(QMKUSBDriver *qmkusbp);
+void qmkusbDataTransmitted(USBDriver *usbp, usbep_t ep);
+void qmkusbDataReceived(USBDriver *usbp, usbep_t ep);
+void qmkusbInterruptTransmitted(USBDriver *usbp, usbep_t ep);
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/tmk_core/protocol/chibios/usb_legacy/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_legacy/usb_main.c
@@ -1,0 +1,1034 @@
+/*
+ * (c) 2015 flabberast <s3+flabbergast@sdfeu.org>
+ *
+ * Based on the following work:
+ *  - Guillaume Duc's raw hid example (MIT License)
+ *    https://github.com/guiduc/usb-hid-chibios-example
+ *  - PJRC Teensy examples (MIT License)
+ *    https://www.pjrc.com/teensy/usb_keyboard.html
+ *  - hasu's TMK keyboard code (GPL v2 and some code Modified BSD)
+ *    https://github.com/tmk/tmk_keyboard/
+ *  - ChibiOS demo code (Apache 2.0 License)
+ *    http://www.chibios.org
+ *
+ * Since some GPL'd code is used, this work is licensed under
+ * GPL v2 or later.
+ */
+
+/*
+ * Implementation notes:
+ *
+ * USBEndpointConfig - Configured using explicit order instead of struct member name.
+ *   This is due to ChibiOS hal LLD differences, which is dependent on hardware,
+ *   "USBv1" devices have `ep_buffers` and "OTGv1" have `in_multiplier`.
+ *   Given `USBv1/hal_usb_lld.h` marks the field as "not currently used" this code file
+ *   makes the assumption this is safe to avoid littering with preprocessor directives.
+ */
+
+#include <ch.h>
+#include <hal.h>
+#include <string.h>
+
+#include "usb_main.h"
+
+#include "host.h"
+#include "chibios_config.h"
+#include "debug.h"
+#include "suspend.h"
+#ifdef SLEEP_LED_ENABLE
+#    include "sleep_led.h"
+#    include "led.h"
+#endif
+#include "wait.h"
+#include "usb_device_state.h"
+#include "usb_descriptor.h"
+#include "usb_driver.h"
+#include "usb_types.h"
+
+#ifdef RAW_ENABLE
+#    include "raw_hid.h"
+#endif
+
+#ifdef NKRO_ENABLE
+#    include "keycode_config.h"
+
+extern keymap_config_t keymap_config;
+#endif
+
+#if defined(CONSOLE_ENABLE)
+#    define RBUF_SIZE 256
+#    include "ring_buffer.h"
+#endif
+
+/* ---------------------------------------------------------
+ *       Global interface variables and declarations
+ * ---------------------------------------------------------
+ */
+
+#ifndef usb_lld_connect_bus
+#    define usb_lld_connect_bus(usbp)
+#endif
+
+#ifndef usb_lld_disconnect_bus
+#    define usb_lld_disconnect_bus(usbp)
+#endif
+
+uint8_t                keyboard_idle __attribute__((aligned(2)))     = 0;
+uint8_t                keyboard_protocol __attribute__((aligned(2))) = 1;
+uint8_t                keyboard_led_state                            = 0;
+volatile uint16_t      keyboard_idle_count                           = 0;
+static virtual_timer_t keyboard_idle_timer;
+
+static void keyboard_idle_timer_cb(struct ch_virtual_timer *, void *arg);
+
+report_keyboard_t keyboard_report_sent = {0};
+report_mouse_t    mouse_report_sent    = {0};
+
+union {
+    uint8_t           report_id;
+    report_keyboard_t keyboard;
+#ifdef EXTRAKEY_ENABLE
+    report_extra_t extra;
+#endif
+#ifdef MOUSE_ENABLE
+    report_mouse_t mouse;
+#endif
+#ifdef DIGITIZER_ENABLE
+    report_digitizer_t digitizer;
+#endif
+#ifdef JOYSTICK_ENABLE
+    report_joystick_t joystick;
+#endif
+} universal_report_blank = {0};
+
+/* ---------------------------------------------------------
+ *            Descriptors and USB driver objects
+ * ---------------------------------------------------------
+ */
+
+/* USB Low Level driver specific endpoint fields */
+#if !defined(usb_lld_endpoint_fields)
+#    define usb_lld_endpoint_fields   \
+        2,        /* IN multiplier */ \
+            NULL, /* SETUP buffer (not a SETUP endpoint) */
+#endif
+
+static const USBDescriptor *usb_get_descriptor_cb(USBDriver *usbp, uint8_t dtype, uint8_t dindex, uint16_t wIndex) {
+    usb_control_request_t *setup = (usb_control_request_t *)usbp->setup;
+
+    static USBDescriptor descriptor;
+    descriptor.ud_string = NULL;
+    descriptor.ud_size   = get_usb_descriptor(setup->wValue.word, setup->wIndex, setup->wLength, (const void **const)&descriptor.ud_string);
+
+    if (descriptor.ud_string == NULL) {
+        return NULL;
+    }
+
+    return &descriptor;
+}
+
+/*
+ * USB notification callback that does nothing.  Needed to work around bugs in
+ * some USB LLDs that fail to resume the waiting thread when the notification
+ * callback pointer is NULL.
+ */
+static void dummy_usb_cb(USBDriver *usbp, usbep_t ep) {
+    (void)usbp;
+    (void)ep;
+}
+
+#ifndef KEYBOARD_SHARED_EP
+/* keyboard endpoint state structure */
+static USBInEndpointState kbd_ep_state;
+/* keyboard endpoint initialization structure (IN) - see USBEndpointConfig comment at top of file */
+static const USBEndpointConfig kbd_ep_config = {
+    USB_EP_MODE_TYPE_INTR,  /* Interrupt EP */
+    NULL,                   /* SETUP packet notification callback */
+    dummy_usb_cb,           /* IN notification callback */
+    NULL,                   /* OUT notification callback */
+    KEYBOARD_EPSIZE,        /* IN maximum packet size */
+    0,                      /* OUT maximum packet size */
+    &kbd_ep_state,          /* IN Endpoint state */
+    NULL,                   /* OUT endpoint state */
+    usb_lld_endpoint_fields /* USB driver specific endpoint fields */
+};
+#endif
+
+#if defined(MOUSE_ENABLE) && !defined(MOUSE_SHARED_EP)
+/* mouse endpoint state structure */
+static USBInEndpointState mouse_ep_state;
+
+/* mouse endpoint initialization structure (IN) - see USBEndpointConfig comment at top of file */
+static const USBEndpointConfig mouse_ep_config = {
+    USB_EP_MODE_TYPE_INTR,  /* Interrupt EP */
+    NULL,                   /* SETUP packet notification callback */
+    dummy_usb_cb,           /* IN notification callback */
+    NULL,                   /* OUT notification callback */
+    MOUSE_EPSIZE,           /* IN maximum packet size */
+    0,                      /* OUT maximum packet size */
+    &mouse_ep_state,        /* IN Endpoint state */
+    NULL,                   /* OUT endpoint state */
+    usb_lld_endpoint_fields /* USB driver specific endpoint fields */
+};
+#endif
+
+#ifdef SHARED_EP_ENABLE
+/* shared endpoint state structure */
+static USBInEndpointState shared_ep_state;
+
+/* shared endpoint initialization structure (IN) - see USBEndpointConfig comment at top of file */
+static const USBEndpointConfig shared_ep_config = {
+    USB_EP_MODE_TYPE_INTR,  /* Interrupt EP */
+    NULL,                   /* SETUP packet notification callback */
+    dummy_usb_cb,           /* IN notification callback */
+    NULL,                   /* OUT notification callback */
+    SHARED_EPSIZE,          /* IN maximum packet size */
+    0,                      /* OUT maximum packet size */
+    &shared_ep_state,       /* IN Endpoint state */
+    NULL,                   /* OUT endpoint state */
+    usb_lld_endpoint_fields /* USB driver specific endpoint fields */
+};
+#endif
+
+#if defined(JOYSTICK_ENABLE) && !defined(JOYSTICK_SHARED_EP)
+/* joystick endpoint state structure */
+static USBInEndpointState joystick_ep_state;
+
+/* joystick endpoint initialization structure (IN) - see USBEndpointConfig comment at top of file */
+static const USBEndpointConfig joystick_ep_config = {
+    USB_EP_MODE_TYPE_INTR,  /* Interrupt EP */
+    NULL,                   /* SETUP packet notification callback */
+    dummy_usb_cb,           /* IN notification callback */
+    NULL,                   /* OUT notification callback */
+    JOYSTICK_EPSIZE,        /* IN maximum packet size */
+    0,                      /* OUT maximum packet size */
+    &joystick_ep_state,     /* IN Endpoint state */
+    NULL,                   /* OUT endpoint state */
+    usb_lld_endpoint_fields /* USB driver specific endpoint fields */
+};
+#endif
+
+#if defined(DIGITIZER_ENABLE) && !defined(DIGITIZER_SHARED_EP)
+/* digitizer endpoint state structure */
+static USBInEndpointState digitizer_ep_state;
+
+/* digitizer endpoint initialization structure (IN) - see USBEndpointConfig comment at top of file */
+static const USBEndpointConfig digitizer_ep_config = {
+    USB_EP_MODE_TYPE_INTR,  /* Interrupt EP */
+    NULL,                   /* SETUP packet notification callback */
+    dummy_usb_cb,           /* IN notification callback */
+    NULL,                   /* OUT notification callback */
+    DIGITIZER_EPSIZE,       /* IN maximum packet size */
+    0,                      /* OUT maximum packet size */
+    &digitizer_ep_state,    /* IN Endpoint state */
+    NULL,                   /* OUT endpoint state */
+    usb_lld_endpoint_fields /* USB driver specific endpoint fields */
+};
+#endif
+
+#ifdef CONSOLE_ENABLE
+/* Console endpoint state structure */
+static USBInEndpointState console_ep_state;
+
+/* Console endpoint initialization structure (IN) - see USBEndpointConfig comment at top of file */
+static const USBEndpointConfig console_ep_config = {
+    USB_EP_MODE_TYPE_INTR,  /* Interrupt EP */
+    NULL,                   /* SETUP packet notification callback */
+    dummy_usb_cb,           /* IN notification callback */
+    NULL,                   /* OUT notification callback */
+    CONSOLE_EPSIZE,         /* IN maximum packet size */
+    0,                      /* OUT maximum packet size */
+    &console_ep_state,      /* IN Endpoint state */
+    NULL,                   /* OUT endpoint state */
+    usb_lld_endpoint_fields /* USB driver specific endpoint fields */
+};
+#endif
+
+#ifdef USB_ENDPOINTS_ARE_REORDERABLE
+typedef struct {
+    size_t              queue_capacity_in;
+    size_t              queue_capacity_out;
+    USBInEndpointState  in_ep_state;
+    USBOutEndpointState out_ep_state;
+    USBInEndpointState  int_ep_state;
+    USBEndpointConfig   inout_ep_config;
+    USBEndpointConfig   int_ep_config;
+    const QMKUSBConfig  config;
+    QMKUSBDriver        driver;
+} usb_driver_config_t;
+#else
+typedef struct {
+    size_t              queue_capacity_in;
+    size_t              queue_capacity_out;
+    USBInEndpointState  in_ep_state;
+    USBOutEndpointState out_ep_state;
+    USBInEndpointState  int_ep_state;
+    USBEndpointConfig   in_ep_config;
+    USBEndpointConfig   out_ep_config;
+    USBEndpointConfig   int_ep_config;
+    const QMKUSBConfig  config;
+    QMKUSBDriver        driver;
+} usb_driver_config_t;
+#endif
+
+#ifdef USB_ENDPOINTS_ARE_REORDERABLE
+/* Reusable initialization structure - see USBEndpointConfig comment at top of file */
+#    define QMK_USB_DRIVER_CONFIG(stream, notification, fixedsize)                                                              \
+        {                                                                                                                       \
+            .queue_capacity_in = stream##_IN_CAPACITY, .queue_capacity_out = stream##_OUT_CAPACITY,                             \
+            .inout_ep_config =                                                                                                  \
+                {                                                                                                               \
+                    stream##_IN_MODE,       /* Interrupt EP */                                                                  \
+                    NULL,                   /* SETUP packet notification callback */                                            \
+                    qmkusbDataTransmitted,  /* IN notification callback */                                                      \
+                    qmkusbDataReceived,     /* OUT notification callback */                                                     \
+                    stream##_EPSIZE,        /* IN maximum packet size */                                                        \
+                    stream##_EPSIZE,        /* OUT maximum packet size */                                                       \
+                    NULL,                   /* IN Endpoint state */                                                             \
+                    NULL,                   /* OUT endpoint state */                                                            \
+                    usb_lld_endpoint_fields /* USB driver specific endpoint fields */                                           \
+                },                                                                                                              \
+            .int_ep_config =                                                                                                    \
+                {                                                                                                               \
+                    USB_EP_MODE_TYPE_INTR,      /* Interrupt EP */                                                              \
+                    NULL,                       /* SETUP packet notification callback */                                        \
+                    qmkusbInterruptTransmitted, /* IN notification callback */                                                  \
+                    NULL,                       /* OUT notification callback */                                                 \
+                    CDC_NOTIFICATION_EPSIZE,    /* IN maximum packet size */                                                    \
+                    0,                          /* OUT maximum packet size */                                                   \
+                    NULL,                       /* IN Endpoint state */                                                         \
+                    NULL,                       /* OUT endpoint state */                                                        \
+                    usb_lld_endpoint_fields     /* USB driver specific endpoint fields */                                       \
+                },                                                                                                              \
+            .config = {                                                                                                         \
+                .usbp        = &USB_DRIVER,                                                                                     \
+                .bulk_in     = stream##_IN_EPNUM,                                                                               \
+                .bulk_out    = stream##_OUT_EPNUM,                                                                              \
+                .int_in      = notification,                                                                                    \
+                .in_buffers  = stream##_IN_CAPACITY,                                                                            \
+                .out_buffers = stream##_OUT_CAPACITY,                                                                           \
+                .in_size     = stream##_EPSIZE,                                                                                 \
+                .out_size    = stream##_EPSIZE,                                                                                 \
+                .fixed_size  = fixedsize,                                                                                       \
+                .ib          = (__attribute__((aligned(4))) uint8_t[BQ_BUFFER_SIZE(stream##_IN_CAPACITY, stream##_EPSIZE)]){},  \
+                .ob          = (__attribute__((aligned(4))) uint8_t[BQ_BUFFER_SIZE(stream##_OUT_CAPACITY, stream##_EPSIZE)]){}, \
+            }                                                                                                                   \
+        }
+#else
+/* Reusable initialization structure - see USBEndpointConfig comment at top of file */
+#    define QMK_USB_DRIVER_CONFIG(stream, notification, fixedsize)                                                              \
+        {                                                                                                                       \
+            .queue_capacity_in = stream##_IN_CAPACITY, .queue_capacity_out = stream##_OUT_CAPACITY,                             \
+            .in_ep_config =                                                                                                     \
+                {                                                                                                               \
+                    stream##_IN_MODE,       /* Interrupt EP */                                                                  \
+                    NULL,                   /* SETUP packet notification callback */                                            \
+                    qmkusbDataTransmitted,  /* IN notification callback */                                                      \
+                    NULL,                   /* OUT notification callback */                                                     \
+                    stream##_EPSIZE,        /* IN maximum packet size */                                                        \
+                    0,                      /* OUT maximum packet size */                                                       \
+                    NULL,                   /* IN Endpoint state */                                                             \
+                    NULL,                   /* OUT endpoint state */                                                            \
+                    usb_lld_endpoint_fields /* USB driver specific endpoint fields */                                           \
+                },                                                                                                              \
+            .out_ep_config =                                                                                                    \
+                {                                                                                                               \
+                    stream##_OUT_MODE,      /* Interrupt EP */                                                                  \
+                    NULL,                   /* SETUP packet notification callback */                                            \
+                    NULL,                   /* IN notification callback */                                                      \
+                    qmkusbDataReceived,     /* OUT notification callback */                                                     \
+                    0,                      /* IN maximum packet size */                                                        \
+                    stream##_EPSIZE,        /* OUT maximum packet size */                                                       \
+                    NULL,                   /* IN Endpoint state */                                                             \
+                    NULL,                   /* OUT endpoint state */                                                            \
+                    usb_lld_endpoint_fields /* USB driver specific endpoint fields */                                           \
+                },                                                                                                              \
+            .int_ep_config =                                                                                                    \
+                {                                                                                                               \
+                    USB_EP_MODE_TYPE_INTR,      /* Interrupt EP */                                                              \
+                    NULL,                       /* SETUP packet notification callback */                                        \
+                    qmkusbInterruptTransmitted, /* IN notification callback */                                                  \
+                    NULL,                       /* OUT notification callback */                                                 \
+                    CDC_NOTIFICATION_EPSIZE,    /* IN maximum packet size */                                                    \
+                    0,                          /* OUT maximum packet size */                                                   \
+                    NULL,                       /* IN Endpoint state */                                                         \
+                    NULL,                       /* OUT endpoint state */                                                        \
+                    usb_lld_endpoint_fields     /* USB driver specific endpoint fields */                                       \
+                },                                                                                                              \
+            .config = {                                                                                                         \
+                .usbp        = &USB_DRIVER,                                                                                     \
+                .bulk_in     = stream##_IN_EPNUM,                                                                               \
+                .bulk_out    = stream##_OUT_EPNUM,                                                                              \
+                .int_in      = notification,                                                                                    \
+                .in_buffers  = stream##_IN_CAPACITY,                                                                            \
+                .out_buffers = stream##_OUT_CAPACITY,                                                                           \
+                .in_size     = stream##_EPSIZE,                                                                                 \
+                .out_size    = stream##_EPSIZE,                                                                                 \
+                .fixed_size  = fixedsize,                                                                                       \
+                .ib          = (__attribute__((aligned(4))) uint8_t[BQ_BUFFER_SIZE(stream##_IN_CAPACITY, stream##_EPSIZE)]){},  \
+                .ob          = (__attribute__((aligned(4))) uint8_t[BQ_BUFFER_SIZE(stream##_OUT_CAPACITY, stream##_EPSIZE)]){}, \
+            }                                                                                                                   \
+        }
+#endif
+
+typedef struct {
+    union {
+        struct {
+#ifdef RAW_ENABLE
+            usb_driver_config_t raw_driver;
+#endif
+#ifdef MIDI_ENABLE
+            usb_driver_config_t midi_driver;
+#endif
+#ifdef VIRTSER_ENABLE
+            usb_driver_config_t serial_driver;
+#endif
+        };
+        usb_driver_config_t array[0];
+    };
+} usb_driver_configs_t;
+
+static usb_driver_configs_t drivers = {
+#ifdef RAW_ENABLE
+#    ifndef RAW_IN_CAPACITY
+#        define RAW_IN_CAPACITY 4
+#    endif
+#    ifndef RAW_OUT_CAPACITY
+#        define RAW_OUT_CAPACITY 4
+#    endif
+#    define RAW_IN_MODE USB_EP_MODE_TYPE_INTR
+#    define RAW_OUT_MODE USB_EP_MODE_TYPE_INTR
+    .raw_driver = QMK_USB_DRIVER_CONFIG(RAW, 0, false),
+#endif
+
+#ifdef MIDI_ENABLE
+#    define MIDI_STREAM_IN_CAPACITY 4
+#    define MIDI_STREAM_OUT_CAPACITY 4
+#    define MIDI_STREAM_IN_MODE USB_EP_MODE_TYPE_BULK
+#    define MIDI_STREAM_OUT_MODE USB_EP_MODE_TYPE_BULK
+    .midi_driver = QMK_USB_DRIVER_CONFIG(MIDI_STREAM, 0, false),
+#endif
+
+#ifdef VIRTSER_ENABLE
+#    define CDC_IN_CAPACITY 4
+#    define CDC_OUT_CAPACITY 4
+#    define CDC_IN_MODE USB_EP_MODE_TYPE_BULK
+#    define CDC_OUT_MODE USB_EP_MODE_TYPE_BULK
+    .serial_driver = QMK_USB_DRIVER_CONFIG(CDC, CDC_NOTIFICATION_EPNUM, false),
+#endif
+};
+
+#define NUM_USB_DRIVERS (sizeof(drivers) / sizeof(usb_driver_config_t))
+
+/* ---------------------------------------------------------
+ *                  USB driver functions
+ * ---------------------------------------------------------
+ */
+
+#define USB_EVENT_QUEUE_SIZE 16
+usbevent_t event_queue[USB_EVENT_QUEUE_SIZE];
+uint8_t    event_queue_head;
+uint8_t    event_queue_tail;
+
+void usb_event_queue_init(void) {
+    // Initialise the event queue
+    memset(&event_queue, 0, sizeof(event_queue));
+    event_queue_head = 0;
+    event_queue_tail = 0;
+}
+
+static inline bool usb_event_queue_enqueue(usbevent_t event) {
+    uint8_t next = (event_queue_head + 1) % USB_EVENT_QUEUE_SIZE;
+    if (next == event_queue_tail) {
+        return false;
+    }
+    event_queue[event_queue_head] = event;
+    event_queue_head              = next;
+    return true;
+}
+
+static inline bool usb_event_queue_dequeue(usbevent_t *event) {
+    if (event_queue_head == event_queue_tail) {
+        return false;
+    }
+    *event           = event_queue[event_queue_tail];
+    event_queue_tail = (event_queue_tail + 1) % USB_EVENT_QUEUE_SIZE;
+    return true;
+}
+
+static inline void usb_event_suspend_handler(void) {
+    usb_device_state_set_suspend(USB_DRIVER.configuration != 0, USB_DRIVER.configuration);
+}
+
+static inline void usb_event_wakeup_handler(void) {
+    suspend_wakeup_init();
+    usb_device_state_set_resume(USB_DRIVER.configuration != 0, USB_DRIVER.configuration);
+}
+
+bool last_suspend_state = false;
+
+void usb_event_queue_task(void) {
+    usbevent_t event;
+    while (usb_event_queue_dequeue(&event)) {
+        switch (event) {
+            case USB_EVENT_SUSPEND:
+                last_suspend_state = true;
+                usb_event_suspend_handler();
+                break;
+            case USB_EVENT_WAKEUP:
+                last_suspend_state = false;
+                usb_event_wakeup_handler();
+                break;
+            case USB_EVENT_CONFIGURED:
+                usb_device_state_set_configuration(USB_DRIVER.configuration != 0, USB_DRIVER.configuration);
+                break;
+            case USB_EVENT_UNCONFIGURED:
+                usb_device_state_set_configuration(false, 0);
+                break;
+            case USB_EVENT_RESET:
+                usb_device_state_set_reset();
+                usb_device_state_set_protocol(USB_PROTOCOL_REPORT);
+                break;
+            default:
+                // Nothing to do, we don't handle it.
+                break;
+        }
+    }
+}
+
+/* Handles the USB driver global events. */
+static void usb_event_cb(USBDriver *usbp, usbevent_t event) {
+    switch (event) {
+        case USB_EVENT_ADDRESS:
+            return;
+
+        case USB_EVENT_CONFIGURED:
+            osalSysLockFromISR();
+            /* Enable the endpoints specified into the configuration. */
+#ifndef KEYBOARD_SHARED_EP
+            usbInitEndpointI(usbp, KEYBOARD_IN_EPNUM, &kbd_ep_config);
+#endif
+#if defined(MOUSE_ENABLE) && !defined(MOUSE_SHARED_EP)
+            usbInitEndpointI(usbp, MOUSE_IN_EPNUM, &mouse_ep_config);
+#endif
+#ifdef SHARED_EP_ENABLE
+            usbInitEndpointI(usbp, SHARED_IN_EPNUM, &shared_ep_config);
+#endif
+#if defined(JOYSTICK_ENABLE) && !defined(JOYSTICK_SHARED_EP)
+            usbInitEndpointI(usbp, JOYSTICK_IN_EPNUM, &joystick_ep_config);
+#endif
+#if defined(DIGITIZER_ENABLE) && !defined(DIGITIZER_SHARED_EP)
+            usbInitEndpointI(usbp, DIGITIZER_IN_EPNUM, &digitizer_ep_config);
+#endif
+#ifdef CONSOLE_ENABLE
+            usbInitEndpointI(usbp, CONSOLE_IN_EPNUM, &console_ep_config);
+#endif
+            for (int i = 0; i < NUM_USB_DRIVERS; i++) {
+#ifdef USB_ENDPOINTS_ARE_REORDERABLE
+                usbInitEndpointI(usbp, drivers.array[i].config.bulk_in, &drivers.array[i].inout_ep_config);
+#else
+                usbInitEndpointI(usbp, drivers.array[i].config.bulk_in, &drivers.array[i].in_ep_config);
+                usbInitEndpointI(usbp, drivers.array[i].config.bulk_out, &drivers.array[i].out_ep_config);
+#endif
+                if (drivers.array[i].config.int_in) {
+                    usbInitEndpointI(usbp, drivers.array[i].config.int_in, &drivers.array[i].int_ep_config);
+                }
+                qmkusbConfigureHookI(&drivers.array[i].driver);
+            }
+            osalSysUnlockFromISR();
+            if (last_suspend_state) {
+                usb_event_queue_enqueue(USB_EVENT_WAKEUP);
+            }
+            usb_event_queue_enqueue(USB_EVENT_CONFIGURED);
+            return;
+        case USB_EVENT_SUSPEND:
+            /* Falls into.*/
+        case USB_EVENT_UNCONFIGURED:
+            /* Falls into.*/
+        case USB_EVENT_RESET:
+            usb_event_queue_enqueue(event);
+            for (int i = 0; i < NUM_USB_DRIVERS; i++) {
+                chSysLockFromISR();
+                /* Disconnection event on suspend.*/
+                qmkusbSuspendHookI(&drivers.array[i].driver);
+                chSysUnlockFromISR();
+            }
+            return;
+
+        case USB_EVENT_WAKEUP:
+            // TODO: from ISR! print("[W]");
+            for (int i = 0; i < NUM_USB_DRIVERS; i++) {
+                chSysLockFromISR();
+                /* Disconnection event on suspend.*/
+                qmkusbWakeupHookI(&drivers.array[i].driver);
+                chSysUnlockFromISR();
+            }
+            usb_event_queue_enqueue(USB_EVENT_WAKEUP);
+            return;
+
+        case USB_EVENT_STALLED:
+            return;
+    }
+}
+
+/*
+ * Appendix G: HID Request Support Requirements
+ *
+ * The following table enumerates the requests that need to be supported by various types of HID class devices.
+ * Device type     GetReport   SetReport   GetIdle     SetIdle     GetProtocol SetProtocol
+ * ------------------------------------------------------------------------------------------
+ * Boot Mouse      Required    Optional    Optional    Optional    Required    Required
+ * Non-Boot Mouse  Required    Optional    Optional    Optional    Optional    Optional
+ * Boot Keyboard   Required    Optional    Required    Required    Required    Required
+ * Non-Boot Keybrd Required    Optional    Required    Required    Optional    Optional
+ * Other Device    Required    Optional    Optional    Optional    Optional    Optional
+ */
+
+static uint8_t set_report_buf[2] __attribute__((aligned(4)));
+
+static void set_led_transfer_cb(USBDriver *usbp) {
+    usb_control_request_t *setup = (usb_control_request_t *)usbp->setup;
+
+    if (setup->wLength == 2) {
+        uint8_t report_id = set_report_buf[0];
+        if ((report_id == REPORT_ID_KEYBOARD) || (report_id == REPORT_ID_NKRO)) {
+            usb_device_state_set_leds(set_report_buf[1]);
+        }
+    } else {
+        usb_device_state_set_leds(set_report_buf[0]);
+    }
+}
+
+static bool usb_requests_hook_cb(USBDriver *usbp) {
+    usb_control_request_t *setup = (usb_control_request_t *)usbp->setup;
+
+    /* Handle HID class specific requests */
+    if ((setup->bmRequestType & (USB_RTYPE_TYPE_MASK | USB_RTYPE_RECIPIENT_MASK)) == (USB_RTYPE_TYPE_CLASS | USB_RTYPE_RECIPIENT_INTERFACE)) {
+        switch (setup->bmRequestType & USB_RTYPE_DIR_MASK) {
+            case USB_RTYPE_DIR_DEV2HOST:
+                switch (setup->bRequest) {
+                    case HID_REQ_GetReport:
+                        switch (setup->wIndex) {
+#ifndef KEYBOARD_SHARED_EP
+                            case KEYBOARD_INTERFACE:
+                                usbSetupTransfer(usbp, (uint8_t *)&keyboard_report_sent, KEYBOARD_REPORT_SIZE, NULL);
+                                return TRUE;
+                                break;
+#endif
+#if defined(MOUSE_ENABLE) && !defined(MOUSE_SHARED_EP)
+                            case MOUSE_INTERFACE:
+                                usbSetupTransfer(usbp, (uint8_t *)&mouse_report_sent, sizeof(mouse_report_sent), NULL);
+                                return TRUE;
+                                break;
+#endif
+#ifdef SHARED_EP_ENABLE
+                            case SHARED_INTERFACE:
+#    ifdef KEYBOARD_SHARED_EP
+                                if (setup->wValue.lbyte == REPORT_ID_KEYBOARD) {
+                                    usbSetupTransfer(usbp, (uint8_t *)&keyboard_report_sent, KEYBOARD_REPORT_SIZE, NULL);
+                                    return true;
+                                }
+#    endif
+#    ifdef MOUSE_SHARED_EP
+                                if (setup->wValue.lbyte == REPORT_ID_MOUSE) {
+                                    usbSetupTransfer(usbp, (uint8_t *)&mouse_report_sent, sizeof(mouse_report_sent), NULL);
+                                    return true;
+                                }
+#    endif
+#endif /* SHARED_EP_ENABLE */
+                            default:
+                                universal_report_blank.report_id = setup->wValue.lbyte;
+                                usbSetupTransfer(usbp, (uint8_t *)&universal_report_blank, setup->wLength, NULL);
+                                return true;
+                        }
+                        break;
+
+                    case HID_REQ_GetProtocol:
+                        if (setup->wIndex == KEYBOARD_INTERFACE) {
+                            static uint8_t keyboard_protocol;
+                            keyboard_protocol = usb_device_state_get_protocol();
+                            usbSetupTransfer(usbp, &keyboard_protocol, sizeof(keyboard_protocol), NULL);
+                            return true;
+                        }
+                        break;
+
+                    case HID_REQ_GetIdle:
+                        usbSetupTransfer(usbp, &keyboard_idle, sizeof(uint8_t), NULL);
+                        return true;
+                }
+                break;
+
+            case USB_RTYPE_DIR_HOST2DEV:
+                switch (setup->bRequest) {
+                    case HID_REQ_SetReport:
+                        switch (setup->wIndex) {
+                            case KEYBOARD_INTERFACE:
+#if defined(SHARED_EP_ENABLE) && !defined(KEYBOARD_SHARED_EP)
+                            case SHARED_INTERFACE:
+#endif
+                                usbSetupTransfer(usbp, set_report_buf, sizeof(set_report_buf), set_led_transfer_cb);
+                                return true;
+                        }
+                        break;
+
+                    case HID_REQ_SetProtocol:
+                        if (setup->wIndex == KEYBOARD_INTERFACE) {
+                            keyboard_protocol = setup->wValue.word;
+#ifdef NKRO_ENABLE
+                            if (!keyboard_protocol && keyboard_idle) {
+#else  /* NKRO_ENABLE */
+                            if (keyboard_idle) {
+#endif /* NKRO_ENABLE */
+                                /* arm the idle timer if boot protocol & idle */
+                                osalSysLockFromISR();
+                                chVTSetI(&keyboard_idle_timer, 4 * TIME_MS2I(keyboard_idle), keyboard_idle_timer_cb, (void *)usbp);
+                                osalSysUnlockFromISR();
+                            }
+                        }
+                        usbSetupTransfer(usbp, NULL, 0, NULL);
+                        return true;
+
+                    case HID_REQ_SetIdle:
+                        keyboard_idle = setup->wValue.hbyte;
+                        /* arm the timer */
+#ifdef NKRO_ENABLE
+                        if (!keymap_config.nkro && keyboard_idle) {
+#else  /* NKRO_ENABLE */
+                        if (keyboard_idle) {
+#endif /* NKRO_ENABLE */
+                            osalSysLockFromISR();
+                            chVTSetI(&keyboard_idle_timer, 4 * TIME_MS2I(keyboard_idle), keyboard_idle_timer_cb, (void *)usbp);
+                            osalSysUnlockFromISR();
+                        }
+                        usbSetupTransfer(usbp, NULL, 0, NULL);
+                        return true;
+                }
+                break;
+        }
+    }
+
+    /* Handle the Get_Descriptor Request for HID class, which is not handled by
+     * the ChibiOS USB driver */
+    if (((setup->bmRequestType & (USB_RTYPE_DIR_MASK | USB_RTYPE_RECIPIENT_MASK)) == (USB_RTYPE_DIR_DEV2HOST | USB_RTYPE_RECIPIENT_INTERFACE)) && (setup->bRequest == USB_REQ_GET_DESCRIPTOR)) {
+        const USBDescriptor *descriptor = usbp->config->get_descriptor_cb(usbp, setup->wValue.lbyte, setup->wValue.hbyte, setup->wIndex);
+        if (descriptor == NULL) {
+            return false;
+        }
+        usbSetupTransfer(usbp, (uint8_t *)descriptor->ud_string, descriptor->ud_size, NULL);
+        return true;
+    }
+
+    for (int i = 0; i < NUM_USB_DRIVERS; i++) {
+        if (drivers.array[i].config.int_in) {
+            // NOTE: Assumes that we only have one serial driver
+            return qmkusbRequestsHook(usbp);
+        }
+    }
+
+    return false;
+}
+
+static void usb_sof_cb(USBDriver *usbp) {
+    osalSysLockFromISR();
+    for (int i = 0; i < NUM_USB_DRIVERS; i++) {
+        qmkusbSOFHookI(&drivers.array[i].driver);
+    }
+    osalSysUnlockFromISR();
+}
+
+/* USB driver configuration */
+static const USBConfig usbcfg = {
+    usb_event_cb,          /* USB events callback */
+    usb_get_descriptor_cb, /* Device GET_DESCRIPTOR request callback */
+    usb_requests_hook_cb,  /* Requests hook callback */
+    usb_sof_cb             /* Start Of Frame callback */
+};
+
+/*
+ * Initialize the USB driver
+ */
+void init_usb_driver(USBDriver *usbp) {
+    for (int i = 0; i < NUM_USB_DRIVERS; i++) {
+#ifdef USB_ENDPOINTS_ARE_REORDERABLE
+        QMKUSBDriver *driver                       = &drivers.array[i].driver;
+        drivers.array[i].inout_ep_config.in_state  = &drivers.array[i].in_ep_state;
+        drivers.array[i].inout_ep_config.out_state = &drivers.array[i].out_ep_state;
+        drivers.array[i].int_ep_config.in_state    = &drivers.array[i].int_ep_state;
+        qmkusbObjectInit(driver, &drivers.array[i].config);
+        qmkusbStart(driver, &drivers.array[i].config);
+#else
+        QMKUSBDriver *driver                     = &drivers.array[i].driver;
+        drivers.array[i].in_ep_config.in_state   = &drivers.array[i].in_ep_state;
+        drivers.array[i].out_ep_config.out_state = &drivers.array[i].out_ep_state;
+        drivers.array[i].int_ep_config.in_state  = &drivers.array[i].int_ep_state;
+        qmkusbObjectInit(driver, &drivers.array[i].config);
+        qmkusbStart(driver, &drivers.array[i].config);
+#endif
+    }
+
+    /*
+     * Activates the USB driver and then the USB bus pull-up on D+.
+     * Note, a delay is inserted in order to not have to disconnect the cable
+     * after a reset.
+     */
+    usbDisconnectBus(usbp);
+    usbStop(usbp);
+    wait_ms(50);
+    usbStart(usbp, &usbcfg);
+    usbConnectBus(usbp);
+
+    chVTObjectInit(&keyboard_idle_timer);
+}
+
+__attribute__((weak)) void restart_usb_driver(USBDriver *usbp) {
+    usbDisconnectBus(usbp);
+    usbStop(usbp);
+
+#if USB_SUSPEND_WAKEUP_DELAY > 0
+    // Some hubs, kvm switches, and monitors do
+    // weird things, with USB device state bouncing
+    // around wildly on wakeup, yielding race
+    // conditions that can corrupt the keyboard state.
+    //
+    // Pause for a while to let things settle...
+    wait_ms(USB_SUSPEND_WAKEUP_DELAY);
+#endif
+
+    usbStart(usbp, &usbcfg);
+    usbConnectBus(usbp);
+}
+
+/* ---------------------------------------------------------
+ *                  Keyboard functions
+ * ---------------------------------------------------------
+ */
+
+/* Idle requests timer code
+ * callback (called from ISR, unlocked state) */
+static void keyboard_idle_timer_cb(struct ch_virtual_timer *timer, void *arg) {
+    (void)timer;
+    USBDriver *usbp = (USBDriver *)arg;
+
+    osalSysLockFromISR();
+
+    /* check that the states of things are as they're supposed to */
+    if (usbGetDriverStateI(usbp) != USB_ACTIVE) {
+        /* do not rearm the timer, should be enabled on IDLE request */
+        osalSysUnlockFromISR();
+        return;
+    }
+
+#ifdef NKRO_ENABLE
+    if (!keymap_config.nkro && keyboard_idle && keyboard_protocol) {
+#else  /* NKRO_ENABLE */
+    if (keyboard_idle && keyboard_protocol) {
+#endif /* NKRO_ENABLE */
+        /* TODO: are we sure we want the KBD_ENDPOINT? */
+        if (!usbGetTransmitStatusI(usbp, KEYBOARD_IN_EPNUM)) {
+            usbStartTransmitI(usbp, KEYBOARD_IN_EPNUM, (uint8_t *)&keyboard_report_sent, KEYBOARD_EPSIZE);
+        }
+        /* rearm the timer */
+        chVTSetI(&keyboard_idle_timer, 4 * TIME_MS2I(keyboard_idle), keyboard_idle_timer_cb, (void *)usbp);
+    }
+
+    /* do not rearm the timer if the condition above fails
+     * it should be enabled again on either IDLE or SET_PROTOCOL requests */
+    osalSysUnlockFromISR();
+}
+
+/* LED status */
+uint8_t keyboard_leds(void) {
+    return keyboard_led_state;
+}
+
+void send_report(uint8_t endpoint, void *report, size_t size) {
+    osalSysLock();
+    if (usbGetDriverStateI(&USB_DRIVER) != USB_ACTIVE) {
+        osalSysUnlock();
+        return;
+    }
+
+    if (usbGetTransmitStatusI(&USB_DRIVER, endpoint)) {
+        /* Need to either suspend, or loop and call unlock/lock during
+         * every iteration - otherwise the system will remain locked,
+         * no interrupts served, so USB not going through as well.
+         * Note: for suspend, need USB_USE_WAIT == TRUE in halconf.h */
+        if (osalThreadSuspendTimeoutS(&(&USB_DRIVER)->epc[endpoint]->in_state->thread, TIME_MS2I(10)) == MSG_TIMEOUT) {
+            osalSysUnlock();
+            return;
+        }
+    }
+    usbStartTransmitI(&USB_DRIVER, endpoint, report, size);
+    osalSysUnlock();
+}
+
+/* prepare and start sending a report IN
+ * not callable from ISR or locked state */
+void send_keyboard(report_keyboard_t *report) {
+    /* If we're in Boot Protocol, don't send any report ID or other funky fields */
+    if (!keyboard_protocol) {
+        send_report(KEYBOARD_IN_EPNUM, &report->mods, 8);
+    } else {
+        send_report(KEYBOARD_IN_EPNUM, report, KEYBOARD_REPORT_SIZE);
+    }
+
+    keyboard_report_sent = *report;
+}
+
+void send_nkro(report_nkro_t *report) {
+#ifdef NKRO_ENABLE
+    send_report(SHARED_IN_EPNUM, report, sizeof(report_nkro_t));
+#endif
+}
+
+/* ---------------------------------------------------------
+ *                     Mouse functions
+ * ---------------------------------------------------------
+ */
+
+void send_mouse(report_mouse_t *report) {
+#ifdef MOUSE_ENABLE
+    send_report(MOUSE_IN_EPNUM, report, sizeof(report_mouse_t));
+    mouse_report_sent = *report;
+#endif
+}
+
+/* ---------------------------------------------------------
+ *                   Extrakey functions
+ * ---------------------------------------------------------
+ */
+
+void send_extra(report_extra_t *report) {
+#ifdef EXTRAKEY_ENABLE
+    send_report(SHARED_IN_EPNUM, report, sizeof(report_extra_t));
+#endif
+}
+
+void send_programmable_button(report_programmable_button_t *report) {
+#ifdef PROGRAMMABLE_BUTTON_ENABLE
+    send_report(SHARED_IN_EPNUM, report, sizeof(report_programmable_button_t));
+#endif
+}
+
+void send_joystick(report_joystick_t *report) {
+#ifdef JOYSTICK_ENABLE
+    send_report(JOYSTICK_IN_EPNUM, report, sizeof(report_joystick_t));
+#endif
+}
+
+void send_digitizer(report_digitizer_t *report) {
+#ifdef DIGITIZER_ENABLE
+    send_report(DIGITIZER_IN_EPNUM, report, sizeof(report_digitizer_t));
+#endif
+}
+
+/* ---------------------------------------------------------
+ *                   Console functions
+ * ---------------------------------------------------------
+ */
+
+#ifdef CONSOLE_ENABLE
+
+int8_t sendchar(uint8_t c) {
+    rbuf_enqueue(c);
+    return 0;
+}
+
+void console_task(void) {
+    if (!rbuf_has_data()) {
+        return;
+    }
+
+    osalSysLock();
+    if (usbGetDriverStateI(&USB_DRIVER) != USB_ACTIVE) {
+        osalSysUnlock();
+        return;
+    }
+
+    if (usbGetTransmitStatusI(&USB_DRIVER, CONSOLE_IN_EPNUM)) {
+        osalSysUnlock();
+        return;
+    }
+
+    // Send in chunks - padded with zeros to 32
+    char    send_buf[CONSOLE_EPSIZE] = {0};
+    uint8_t send_buf_count           = 0;
+    while (rbuf_has_data() && send_buf_count < CONSOLE_EPSIZE) {
+        send_buf[send_buf_count++] = rbuf_dequeue();
+    }
+
+    usbStartTransmitI(&USB_DRIVER, CONSOLE_IN_EPNUM, (const uint8_t *)send_buf, CONSOLE_EPSIZE);
+    osalSysUnlock();
+}
+
+#endif /* CONSOLE_ENABLE */
+
+#ifdef RAW_ENABLE
+void send_raw_hid(uint8_t *data, uint8_t length) {
+    // TODO: implement variable size packet
+    if (length != RAW_EPSIZE) {
+        return;
+    }
+    chnWrite(&drivers.raw_driver.driver, data, length);
+}
+
+void raw_hid_task(void) {
+    uint8_t buffer[RAW_EPSIZE];
+    size_t  size = 0;
+    do {
+        size = chnReadTimeout(&drivers.raw_driver.driver, buffer, sizeof(buffer), TIME_IMMEDIATE);
+        if (size > 0) {
+            raw_hid_receive(buffer, size);
+        }
+    } while (size > 0);
+}
+
+#endif
+
+#ifdef MIDI_ENABLE
+
+void send_midi_packet(MIDI_EventPacket_t *event) {
+    chnWrite(&drivers.midi_driver.driver, (uint8_t *)event, sizeof(MIDI_EventPacket_t));
+}
+
+bool recv_midi_packet(MIDI_EventPacket_t *const event) {
+    size_t size = chnReadTimeout(&drivers.midi_driver.driver, (uint8_t *)event, sizeof(MIDI_EventPacket_t), TIME_IMMEDIATE);
+    return size == sizeof(MIDI_EventPacket_t);
+}
+void midi_ep_task(void) {
+    uint8_t buffer[MIDI_STREAM_EPSIZE];
+    size_t  size = 0;
+    do {
+        size = chnReadTimeout(&drivers.midi_driver.driver, buffer, sizeof(buffer), TIME_IMMEDIATE);
+        if (size > 0) {
+            MIDI_EventPacket_t event;
+            recv_midi_packet(&event);
+        }
+    } while (size > 0);
+}
+#endif
+
+#ifdef VIRTSER_ENABLE
+
+void virtser_init(void) {}
+
+void virtser_send(const uint8_t byte) {
+    chnWrite(&drivers.serial_driver.driver, &byte, 1);
+}
+
+__attribute__((weak)) void virtser_recv(uint8_t c) {
+    // Ignore by default
+}
+
+void virtser_task(void) {
+    uint8_t numBytesReceived = 0;
+    uint8_t buffer[16];
+    do {
+        numBytesReceived = chnReadTimeout(&drivers.serial_driver.driver, buffer, sizeof(buffer), TIME_IMMEDIATE);
+        for (int i = 0; i < numBytesReceived; i++) {
+            virtser_recv(buffer[i]);
+        }
+    } while (numBytesReceived > 0);
+}
+
+#endif

--- a/tmk_core/protocol/chibios/usb_legacy/usb_main.h
+++ b/tmk_core/protocol/chibios/usb_legacy/usb_main.h
@@ -1,0 +1,60 @@
+/*
+ * (c) 2015 flabberast <s3+flabbergast@sdfeu.org>
+ *
+ * Based on the following work:
+ *  - Guillaume Duc's raw hid example (MIT License)
+ *    https://github.com/guiduc/usb-hid-chibios-example
+ *  - PJRC Teensy examples (MIT License)
+ *    https://www.pjrc.com/teensy/usb_keyboard.html
+ *  - hasu's TMK keyboard code (GPL v2 and some code Modified BSD)
+ *    https://github.com/tmk/tmk_keyboard/
+ *  - ChibiOS demo code (Apache 2.0 License)
+ *    http://www.chibios.org
+ *
+ * Since some GPL'd code is used, this work is licensed under
+ * GPL v2 or later.
+ */
+
+#pragma once
+
+#include <ch.h>
+#include <hal.h>
+
+/* -------------------------
+ * General USB driver header
+ * -------------------------
+ */
+
+/* The USB driver to use */
+#ifndef USB_DRIVER
+#    define USB_DRIVER USBD1
+#endif // USB_DRIVER
+
+/* Initialize the USB driver and bus */
+void init_usb_driver(USBDriver *usbp);
+
+/* Restart the USB driver and bus */
+void restart_usb_driver(USBDriver *usbp);
+
+/* ---------------
+ * USB Event queue
+ * ---------------
+ */
+
+/* Initialisation of the FIFO */
+void usb_event_queue_init(void);
+
+/* Task to dequeue and execute any handlers for the USB events on the main thread */
+void usb_event_queue_task(void);
+
+/* --------------
+ * Console header
+ * --------------
+ */
+
+#ifdef CONSOLE_ENABLE
+
+/* Putchar over the USB console */
+int8_t sendchar(uint8_t c);
+
+#endif /* CONSOLE_ENABLE */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Added legacy ChibiOS USB endpoints before async for SN32F260.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
